### PR TITLE
BulmaからBootstrapにCSSフレームワークを変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,10 @@ AllCops:
     - 'test/**/*'
     - 'spec/**/*'
 
-# 要検討
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
   Enabled: false
 
 Metrics/AbcSize:

--- a/Gemfile
+++ b/Gemfile
@@ -26,14 +26,13 @@ gem 'jbuilder', '~> 2.7'
 # gem 'image_processing', '~> 1.2'
 
 # --- Add Gems ---
-# Reduces boot times through caching; required in config/boot.rb
-gem "bulma-rails", "~> 0.9.3"
 
 # Japanese localization
 gem 'rails-i18n'
 
 # Frontend
-gem 'bootstrap', '~> 5.1', '>= 5.1.3'
+# bootstrap
+gem 'bootstrap', '~> 5.0.2'
 gem 'slim-rails'
 gem 'html2slim'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,16 +76,14 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bootstrap (5.1.3)
+    bootstrap (5.0.2)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.3, < 3)
+      popper_js (>= 2.9.2, < 3)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     bullet (7.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    bulma-rails (0.9.3)
-      sassc (~> 2.0)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -322,9 +320,8 @@ DEPENDENCIES
   annotate
   better_errors
   binding_of_caller
-  bootstrap (~> 5.1, >= 5.1.3)
+  bootstrap (~> 5.0.2)
   bullet
-  bulma-rails (~> 0.9.3)
   byebug
   faker
   html2slim

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,9 @@
  *= require_self
  */
 
-@import "bulma";
+//@import "~bootstrap/scss/bootstrap.scss";
+@import "../../../node_modules/bootstrap/scss/bootstrap.scss";
+
 .oyatsu_tooltip{
     position: relative;
     cursor: pointer;

--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -11,12 +11,12 @@ class BasketsController < ApplicationController
   end
 
   def create
-    @basket = Basket.new(basket_params)
-    @basket.user_id = current_user.id
+    @basket = @user.baskets.build(basket_params)
 
     if @basket.save
       redirect_to choose_oyatsu_path, success: 'せいこう'
     else
+      # TODO: renderに変更
       redirect_to choose_oyatsu_path, success: 'しっぱい'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,3 @@
-# User
 class UsersController < ApplicationController
   before_action :set_current_user, only: %i[edit update]
   skip_before_action :require_login, only: %i[new create], raise: false

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,8 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+import 'bootstrap';
+import '../stylesheets/application';
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,0 +1,1 @@
+@import '~bootstrap/scss/bootstrap.scss';

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,2 +1,0 @@
-h1 Users#show
-p Find me in app/views/users/show.html.slim

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
-    "bulma": "^0.9.4",
+    "bootstrap": "^5.1.3",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,6 +1562,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
+  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1698,11 +1703,6 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
-
-bulma@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.4.tgz#0ca8aeb1847a34264768dba26a064c8be72674a1"
-  integrity sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# **概要**
BulmaからBootstrapにCSSフレームワークを変更しました。
また、各種controllerなどで軽微なリファクタリングを行っています。

# **影響範囲**
アプリケーション全般。

# **確認方法**
1. ローカルホストにダウンロード後にlocalhostのルート画面に遷移する。
2. CSSフレームワークが適応されていないことを確認する。

# **チェックリスト**

- [ ] 対応するIssueを作成した
- [ ] Lint のチェックをパスした
- [ ] 確認方法の内容を満たした

# **コメント**
移行bootstrap用に画面を差し替える。