### PR TITLE
Add: Ensokuテーブルとモデルを追加

### DIFF
--- a/app/models/ensoku.rb
+++ b/app/models/ensoku.rb
@@ -1,0 +1,9 @@
+class Ensoku < ApplicationRecord
+  belongs_to :user
+  validates :purse, presence: true, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 300
+  }
+  validates :comment, length: { maximum: 65_535 }
+end

--- a/db/migrate/20220627104241_remove_purse_and_comment_from_users.rb
+++ b/db/migrate/20220627104241_remove_purse_and_comment_from_users.rb
@@ -1,0 +1,6 @@
+class RemovePurseAndCommentFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :purse, :integer
+    remove_column :users, :comment, :string
+  end
+end

--- a/db/migrate/20220627104454_create_ensokus.rb
+++ b/db/migrate/20220627104454_create_ensokus.rb
@@ -1,0 +1,11 @@
+class CreateEnsokus < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ensokus do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :parse, null: false
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_071101) do
+ActiveRecord::Schema.define(version: 2022_06_27_104454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 2022_06_23_071101) do
     t.index ["user_id"], name: "index_baskets_on_user_id"
   end
 
+  create_table "ensokus", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "parse", null: false
+    t.string "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_ensokus_on_user_id"
+  end
+
   create_table "oyatsus", force: :cascade do |t|
     t.string "name", null: false
     t.string "genre", null: false
@@ -36,8 +45,6 @@ ActiveRecord::Schema.define(version: 2022_06_23_071101) do
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "purse", null: false
-    t.string "comment"
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"
@@ -54,4 +61,5 @@ ActiveRecord::Schema.define(version: 2022_06_23_071101) do
 
   add_foreign_key "baskets", "oyatsus"
   add_foreign_key "baskets", "users"
+  add_foreign_key "ensokus", "users"
 end


### PR DESCRIPTION
# **概要**

Userモデルとbasketモデルの中間にEnsokuモデルを新たに作成しました。
このモデルを置くことで、各ユーザーが複数回遠足に行くことが可能になる。

詳しくは更新したER図を参照。

# **影響範囲**

Userモデル
Ensokuモデル

# **確認方法**

1. Userテーブルからpurse, commentカラムを削除し、Ensokuテーブルを追加したので `bundle exec rails db:migrate` を実行してください

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**

これによりいくつもエラーが生じてます。エラー対応はイシューで別途に報告。