### PR TITLE
Change: loginコントローラーとensokuコントローラーの切り分け

### DIFF
--- a/app/assets/stylesheets/oyatsus.scss
+++ b/app/assets/stylesheets/oyatsus.scss
@@ -41,6 +41,7 @@
   background-image: linear-gradient(120deg, #fdfbfb 0%, #ebedee 100%);
 }
 
+// ボタン
 .btn.btn-outline-dark {
   color: #ff5858;
   border-color: #ff5858;
@@ -51,6 +52,10 @@
   border-color: white;
 }
 
+.btn-outline-dark:active {
+  background-color: #ff5858!important;
+  border-color: #ff5858!important;
+}
 // ページネーション
 .pagination {
   justify-content: center;

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -11,7 +11,7 @@ class Admin::UserSessionsController < Admin::BaseController
     if @user
       redirect_back_or_to admin_root_path, success: t('.success')
     else
-      flash.now[:danger] = t('.failed')
+      flash.now[:danger] = t('.failure')
       render 'new'
     end
   end

--- a/app/controllers/ensokus_controller.rb
+++ b/app/controllers/ensokus_controller.rb
@@ -1,4 +1,6 @@
 class EnsokusController < ApplicationController
   # 遠足一覧画面
   def index; end
+
+  def new; end
 end

--- a/app/controllers/ensokus_controller.rb
+++ b/app/controllers/ensokus_controller.rb
@@ -1,6 +1,17 @@
 class EnsokusController < ApplicationController
+  before_action :require_login
+
   # 遠足一覧画面
+  # Userの全遠足結果を取得
   def index; end
 
+  # ログイン後のtop画面
+  # 新規遠足作成のボタンを置く
   def new; end
+
+  # 新規遠足作成
+  def create
+    @ensoku = current_user.ensokus.create
+    redirect_to choose_oyatsu_path(ensoku: @ensoku)
+  end
 end

--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -9,7 +9,7 @@ class MyPagesController < ApplicationController
     if @user.update(user_params)
       redirect_to my_page_path, success: t('.success')
     else
-      flash.now[:danger] = t('.failed')
+      flash.now[:danger] = t('.failure')
       render :edit
     end
   end

--- a/app/controllers/oyatsus_controller.rb
+++ b/app/controllers/oyatsus_controller.rb
@@ -7,12 +7,7 @@ class OyatsusController < ApplicationController
     @oyatsus = @q.result.page(params[:page])
   end
 
-  private
-
   def set_ensoku
-    if @ensoku.blank?
-
-    end
-    @ensoku = current_user.ensokus.create if current_user.ensokus.blank?
+    @ensoku = Ensoku.find(params[:ensoku])
   end
 end

--- a/app/controllers/oyatsus_controller.rb
+++ b/app/controllers/oyatsus_controller.rb
@@ -1,17 +1,18 @@
 # Oyatsus Contorller
 class OyatsusController < ApplicationController
-  before_action :require_login
+  before_action :require_login, :set_ensoku
 
   def index
-    @ensoku = current_user.ensokus.create if @ensoku.blank?
     @q = Oyatsu.ransack(params[:q])
     @oyatsus = @q.result.page(params[:page])
   end
 
   private
 
-  # 紐づく遠足がなければ遠足作成
-  def check_ensoku
+  def set_ensoku
+    if @ensoku.blank?
 
+    end
+    @ensoku = current_user.ensokus.create if current_user.ensokus.blank?
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -27,7 +27,7 @@ class PasswordResetsController < ApplicationController
     if @user.change_password(params[:user][:password])
       redirect_to root_path, success: t('.success')
     else
-      flash.now[:danger] = t('.fail')
+      flash.now[:danger] = t('.failure')
       render :edit
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,15 +1,17 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create], raise: false
 
-  def new; end
+  def new
+    redirect_to new_user_ensoku_path(current_user.id) if logged_in?
+  end
 
   def create
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to choose_oyatsu_path, success: t('.success')
+      redirect_back_or_to new_user_ensoku_path(current_user.id), success: t('.success')
     else
-      flash.now[:danger] = t('.failed')
+      flash.now[:danger] = t('.failure')
       render 'new'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to '/', success: t('.success')
     else
-      flash.now[:danger] = t('.failed')
+      flash.now[:danger] = t('.failure')
       render :new
     end
   end

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -4,5 +4,5 @@ div.main-wrapper.main-bg.main-bg-img
     // TODO: ロゴ画像
     // = link_to
     h1.mt-3.mb-3.font-weight-normal = t('.title')
-    = link_to 'おやつをえらぶ', choose_oyatsu_path, class: 'btn btn-outline-light mt-3 btn-lg'
+    = link_to 'おやつをえらぶ', user_ensokus_path, method: :post,  class: 'btn btn-outline-light mt-3 btn-lg'
     = render 'shared/how_to_play'

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -4,5 +4,5 @@ div.main-wrapper.main-bg.main-bg-img
     // TODO: ロゴ画像
     // = link_to
     h1.mt-3.mb-3.font-weight-normal = t('.title')
-    = render 'login_form'
+    = link_to 'おやつをえらぶ', choose_oyatsu_path, class: 'btn btn-outline-light mt-3 btn-lg'
     = render 'shared/how_to_play'

--- a/app/views/oyatsus/_oyatsu.html.slim
+++ b/app/views/oyatsus/_oyatsu.html.slim
@@ -12,6 +12,8 @@ section.col-4.col-lg-2.mb-3
           = link_to '#', type: 'button', class: 'btn btn-outline-dark'
             i.fa-solid.fa-minus
         div.col
+          /- if ensokuに対象のおやつが入っている。ensoku.basket.quantity
+        div.col
           = link_to '#', type: 'button', class: 'btn btn-outline-dark'
             i.fa-solid.fa-plus
 

--- a/app/views/shared/_how_to_play.html.slim
+++ b/app/views/shared/_how_to_play.html.slim
@@ -1,0 +1,8 @@
+h1.mt-3 あそびかた
+div.columns
+  div.column
+    p 1. すきなおかしをクリック
+  div.column
+    p 2. いくつ買うかえらんでね
+  div.column
+    p 3. きまったらレジにいこう

--- a/app/views/user_sessions/_login_form.html.slim
+++ b/app/views/user_sessions/_login_form.html.slim
@@ -1,0 +1,17 @@
+section.form-box.border
+  // TODO: twitterログイン
+  div.twitter-box
+    p.border-bottom ツイッターログイン
+  = form_with url: login_path, local: true do |f|
+    div.form-group
+      = f.label :email, t('.email')
+      = f.email_field :email, id: 'email', class: 'form-control', blaceholder: 'email'
+    div.field.has-text-centered
+      = f.label :password, t('.password'), for: 'password'
+      = f.password_field :password, id: 'password', class: 'form-control', blaceholder: 'email'
+    /= f.submit t('.login'), class: 'btn btn-primary' TODO言語対応
+    = f.submit 'ろぐいん', class: 'btn btn-outline-light'
+div
+  = link_to 'しんきとうろく', new_user_path, class: 'btn btn-outline-light mt-3'
+div
+  = link_to 'ぱすわーどわすれちゃった', new_password_reset_path, class: 'btn btn-outline-light mt-3'

--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  ensokus:
+    new:
+      title: '遠足のおやつは300円まで！'
+

--- a/config/locales/views/user_sessions/ja.yml
+++ b/config/locales/views/user_sessions/ja.yml
@@ -2,4 +2,6 @@ ja:
   user_sessions:
     new:
       title: '遠足のおやつは300円まで！'
-
+    create:
+      success: 'ろぐいんしたよ。'
+      failure: 'ろぐいんしっぱい！もういちどためしてみてね。'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,10 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]
 
 
-  resources :ensokus, only: %i[index]
   resources :users, only: %i[index new create] do
-    resources :baskets, only: %i[index show new create destroy], shallow: true
+    resources :ensokus, shallow:true  do
+      resources :baskets, only: %i[index show new create destroy], shallow: true
+    end
   end
 
   namespace :admin do


### PR DESCRIPTION
# **概要**
ensokuコントローラー導入に伴ったlogin周りのルーティングやコントローラーの処理を変更。

# **影響範囲**

- ログイン画面
- トップ画面

# **確認方法**

1. ログインをしない場合、画面のトップがログイン画面であることを確認してください。
2. ログインをしている場合、画面のトップが「おやつをえらぶ」のボタンがある画面であることを確認してください。また、URLがユーザー独自のものであることを確認してください。

# **チェックリスト**

- [ ] 対応するIssueを作成した
- [ ] Lint のチェックをパスした
- [ ] 確認方法の内容を満たした

# **コメント**

URLに関しては修正が必要。別イシュー化。