### PR TITLE
選択したおやつ(一覧)画面を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'sorcery', '~> 0.16.3'
 
 # Japanese localization
 gem 'rails-i18n'
+gem 'enum_help'
 
 # Frontend
 # bootstrap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     faker (2.20.0)
       i18n (>= 1.8.11, < 2)
@@ -375,6 +377,7 @@ DEPENDENCIES
   bullet
   byebug
   config
+  enum_help
   faker
   font-awesome-sass
   html2slim

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import 'bootstrap/scss/bootstrap';
 @import "admin-lte/dist/css/adminlte.min.css";
 @import "./oyatsus.scss";
+@import "./ensokus.scss";
 
 .main-wrapper {
   display: -ms-flexbox;

--- a/app/assets/stylesheets/ensokus.scss
+++ b/app/assets/stylesheets/ensokus.scss
@@ -1,0 +1,7 @@
+th {
+  vertical-align: middle;
+}
+
+td {
+  vertical-align: middle;
+}

--- a/app/controllers/oyatsus_controller.rb
+++ b/app/controllers/oyatsus_controller.rb
@@ -1,13 +1,15 @@
 # Oyatsus Contorller
 class OyatsusController < ApplicationController
-  before_action :require_login, :set_ensoku
+  before_action :require_login, :check_ensoku
 
   def index
     @q = Oyatsu.ransack(params[:q])
     @oyatsus = @q.result.page(params[:page])
   end
 
-  def set_ensoku
-    @ensoku = Ensoku.find(params[:ensoku])
+  private
+
+  def check_ensoku
+    redirect_to new_users_ensoku_path if @ensoku.blank?
   end
 end

--- a/app/controllers/oyatsus_controller.rb
+++ b/app/controllers/oyatsus_controller.rb
@@ -10,6 +10,10 @@ class OyatsusController < ApplicationController
   private
 
   def check_ensoku
-    redirect_to new_users_ensoku_path if @ensoku.blank?
+    if params[:ensoku].present?
+      @ensoku = Ensoku.find(params[:ensoku])
+    else
+      redirect_to new_users_ensoku_path
+    end
   end
 end

--- a/app/views/ensokus/_ensoku.html.slim
+++ b/app/views/ensokus/_ensoku.html.slim
@@ -1,14 +1,7 @@
-div.container
-  div.row
-    div.col
-      p のこりのおこづかい:
-      = ensoku.purse
-    div.col
-      p こめんと:
-      = ensoku.comment
-    div.col
-      p すてーたす:
-      = ensoku.status
-    div.col
-      p えらんだおやつのかず
-      = ensoku.baskets.count
+tr
+  th.align-middle scope='row'
+    = ensoku_counter + 1
+  td.align-middle = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
+  td.align-middle = ensoku.purse
+  td.align-middle = ensoku.status_i18n
+  td.align-middle = link_to t('.edit'), '#', class: 'btn btn-sm btn-outline-light'

--- a/app/views/ensokus/index.html.slim
+++ b/app/views/ensokus/index.html.slim
@@ -1,5 +1,15 @@
 - content_for :title
 div.main-wrapper.main-bg.main-bg-img
-  div.main-inner-text
+  div.main-inner-text.p-5
     h1.mt-3.mb-3.font-weight-normal = t('.title')
-    = render @ensokus
+    div.table-responsive-lg
+      table.table
+        thead
+          tr
+            th scope='col' = t('.number')
+            th scope='col' = t('.comment')
+            th scope='col' = t('.purse')
+            th scope='col' = t('.status')
+            th scope='col' = t('.edit')
+        tbody
+          = render @ensokus

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -5,8 +5,8 @@ div.main-wrapper.main-bg.main-bg-img
     // = link_to
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     div
-      = link_to t('choose_anew'), users_ensokus_path, method: :post,  class: 'btn btn-outline-light mt-3 btn-lg'
+      = link_to t('.new'), users_ensokus_path, method: :post,  class: 'btn btn-outline-light mt-3 btn-lg'
     - if current_user.ensokus.present?
       div
-        = link_to t('.choose_from_a_series'), users_ensokus_path, class: 'btn btn-outline-light mt-3 btn-lg'
+        = link_to t('.continue'), users_ensokus_path, class: 'btn btn-outline-light mt-3 btn-lg'
     = render 'shared/how_to_play'

--- a/app/views/shared/_toggle.html.slim
+++ b/app/views/shared/_toggle.html.slim
@@ -12,7 +12,7 @@ div#navbarSupportedContent.collapse.navbar-collapse.justify-content-right
     li.nav-item
       = link_to "まいぺーじ: #{current_user.name}", my_page_path, class: 'nav-link'
     li.nav-item
-      = link_to 'おやつをえらぶ', choose_oyatsu_path, class: 'nav-link'
+      = link_to 'おやつをえらぶ', new_users_ensoku_path, class: 'nav-link'
     li.nav-item
       = link_to 'みんなのおやつ', users_path, class: 'nav-link'
     li.nav-item

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,7 +10,10 @@ ja:
         password_confirmation: 'ぱすわーど(かくにん)'
   enums:
     user:
+      general: '一般'
+      admin: '管理者'
+    ensoku:
       status:
-        selecting: 'せんたくちゅう'
+        selecting: 'とちゅう'
         close: 'ひとにみせない'
         open: 'ひとにみせる'

--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -2,5 +2,5 @@ ja:
   ensokus:
     new:
       title: '遠足のおやつは300円まで！'
-      choose_anew: 'あたらしくえらぶ'
-      choose_from_a_series: 'つづきからえらぶ'
+      new: 'あたらしくえらぶ'
+      continue: 'つづきからえらぶ'

--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -1,6 +1,16 @@
 ja:
   ensokus:
+    index:
+      title: 'えらんだおやつ'
+      comment: 'ひとこと'
+      number: 'ばんごう'
+      purse: 'のこったおこづかい'
+      status: 'じょうたい'
+      edit: 'こうしんする？'
     new:
       title: '遠足のおやつは300円まで！'
       new: 'あたらしくえらぶ'
       continue: 'つづきからえらぶ'
+    ensoku:
+      no_comment: 'のーこめんと'
+      edit: 'こうしん'


### PR DESCRIPTION
# **概要**

選択したおやつ(一覧)画面を追加しました。
また、画面遷移や文字のバグやヘッダーのリンク先などを修正しました。

# **影響範囲**

選択したおやつ(一覧)画面

# **確認方法**

1. Gem を追加したので `bundle install` を実行してください
2. http://localhost:3000/users/ensokus にアクセスし、選択したおやつ(一覧)画面が表示されることを確認してください
3. おやつ選択画面の「つづきからえらぶ」から、選択したおやつ(一覧)画面が表示されることを確認してください
4.マイページのえらんだおやつを観るから、選択したおやつ(一覧)画面が表示されることを確認してください 

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**
特になし。
