### PR TITLE
Fix: ユーザー新規登録画面とパスワードリセット画面を修正

### DIFF
--- a/app/views/password_resets/edit.html.slim
+++ b/app/views/password_resets/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :title, t('.title')
-div.main-wrapper
+div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    h1.mt-3.mb-3.font-weight-normal
-      = t('.title')
+    h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.form-box.border
       = render 'form', user: @user

--- a/app/views/password_resets/new.html.slim
+++ b/app/views/password_resets/new.html.slim
@@ -1,12 +1,10 @@
 - content_for :title, t('.title')
-div.main-wrapper
+div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    h1.mt-3.mb-3.font-weight-normal
-      = t('.title')
+    h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.form-box.border
       = form_with url: password_resets_path, locale: true, method: :post do |f|
         div.form-group
-          = f.label :email, t('.email')
-          = f.email_field :email, id: 'email', class: 'form-control', blaceholder: 'email'
-        /= f.submit t('.submit'), class: 'btn btn-light'
-        = f.submit 'きいてみる', class: 'btn btn-outline-light'
+          = f.label :email, User.human_attribute_name(:email)
+          = f.email_field :email, id: 'email', class: 'form-control', placeholder: t('.email')
+        = f.submit t('.submit'), class: 'btn btn-outline-light'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -16,6 +16,8 @@ header
           = render 'shared/toggle'
       - else
         div.col.text-end
-          = link_to 'ろぐいん', root_path, class: 'btn btn-outline-light mx-3'
-          = link_to 'しんきとうろく', new_user_path, class: 'btn btn-outline-light'
+          - unless current_page?(root_path)
+            = link_to 'ろぐいん', root_path, class: 'btn btn-outline-light mx-3'
+          - unless current_page?(new_users_path)
+            = link_to 'しんきとうろく', new_users_path, class: 'btn btn-outline-light'
 

--- a/app/views/user_sessions/_login_form.html.slim
+++ b/app/views/user_sessions/_login_form.html.slim
@@ -12,6 +12,6 @@ section.form-box.border
     /= f.submit t('.login'), class: 'btn btn-primary' TODO言語対応
     = f.submit 'ろぐいん', class: 'btn btn-outline-light'
 div
-  = link_to 'しんきとうろく', new_user_path, class: 'btn btn-outline-light mt-3'
+  = link_to 'しんきとうろく', new_users_path, class: 'btn btn-outline-light mt-3'
 div
   = link_to 'ぱすわーどわすれちゃった', new_password_reset_path, class: 'btn btn-outline-light mt-3'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,8 +1,6 @@
 - content_for :title
 div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    // TODO: ロゴ画像
-    // = link_to
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     = render 'login_form'
     = render 'shared/how_to_play'

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -3,14 +3,14 @@
     = render 'shared/error_messages', object: f.object
   div.form-group
     = f.label :name, User.human_attribute_name(:name)
-    = f.text_field :name,  class: 'form-control', placeholder: t('name')
+    = f.text_field :name,  class: 'form-control', placeholder: t('.name')
   div.form-group
     = f.label :email, User.human_attribute_name(:email)
-    = f.email_field :email, class: 'form-control', placeholder: t('email')
+    = f.email_field :email, class: 'form-control', placeholder: t('.email')
   div.form-group
     = f.label :password, User.human_attribute_name(:password)
-    = f.password_field :password, class: 'form-control', placeholder: t('password')
+    = f.password_field :password, class: 'form-control', placeholder: t('.password')
   div.form-group
     = f.label :password_confirmation, User.human_attribute_name(:password_confirmation)
-    = f.password_field :password_confirmation, class: 'form-control', placeholder: t('password_confirmation')
+    = f.password_field :password_confirmation, class: 'form-control', placeholder: t('.password_confirmation')
   = f.submit t('.login'), class: 'btn btn-light'

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,8 +1,6 @@
 - content_for :title, t('.title')
-div.main-wrapper
+div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    h1.mt-3.mb-3.font-weight-normal
-      / TODO: 置き換え
-      = t('.title')
+    h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.form-box.border
       = render 'form', user: @user

--- a/config/locales/views/password_resets/ja.yml
+++ b/config/locales/views/password_resets/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  password_resets:
+    new:
+      title: 'ぱすわーどりせっと'
+      email: 'とうろくしてるめーるあどれす'
+      submit: 'りせっとめーるをおくる'
+    create:
+      send: 'めーるをおくったよ！'
+    edit:
+      title: 'ぱすわーどさいとうろく'
+    update:
+      sucess: 'ぱすわーどをこうしんしたよ！'
+    form:
+      email: 'ふりーあどれすでいいよ'
+      password: 'わすれないように'
+      password_confirmation: 'かくにんしよう'
+      submit: 'さいとうろく'

--- a/config/locales/views/users/ja.yml
+++ b/config/locales/views/users/ja.yml
@@ -1,4 +1,12 @@
 ja:
   users:
+    new:
+      title: 'しんきとうろく'
+    form:
+      name: 'にっくねーむ'
+      email: 'ふりーあどれすでいいよ'
+      password: 'わすれないように'
+      password_confirmation: 'かくにんしよう'
+      login: 'とうろく'
     update:
-      success: こうしんしました！
+      success: 'こうしんしました！'


### PR DESCRIPTION
# **概要**

ユーザー新規登録画面とパスワードリセット画面が崩れていたので修正しました。
また、i18nでの記述を追加しました。

# **影響範囲**

- ユーザー新規登録画面
- パスワードリセット画面

# **確認方法**

1. ユーザー新規登録画面を確認してください。
2. パスワードリセットメール申請画面を確認してください。
3. letter openerから送られてくるメールから飛べるパスワードリセット画面を確認してください。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした
