### PR TITLE
Add: えらんだおやつ(詳細)画面を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -120,3 +120,9 @@ a {
   margin-bottom: 10px;
 }
 
+h3 {
+  border-bottom: 1px solid white;
+  margin-bottom: 1rem;
+  display: inline-block;
+  color: #EBEBEB
+}

--- a/app/controllers/ensokus_controller.rb
+++ b/app/controllers/ensokus_controller.rb
@@ -1,5 +1,6 @@
 class EnsokusController < ApplicationController
   before_action :require_login
+  before_action :set_ensoku, only: %i[show edit]
 
   # 遠足一覧画面
   # Userの全遠足結果を取得
@@ -15,5 +16,15 @@ class EnsokusController < ApplicationController
   def create
     @ensoku = current_user.ensokus.create
     redirect_to choose_oyatsu_path(ensoku: @ensoku)
+  end
+
+  def show; end
+
+  def edit; end
+
+  private
+
+  def set_ensoku
+    @ensoku = Ensoku.find(params[:id])
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -18,6 +18,6 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to root_path, success: t('.logout')
   end
 end

--- a/app/views/ensokus/_choosed_oyatsu.html.slim
+++ b/app/views/ensokus/_choosed_oyatsu.html.slim
@@ -1,0 +1,6 @@
+section.col-4.col-lg-2.mb-3
+  div.card.card-wrapper.mb-4.box-shadow.h-100.text-center
+    div.card-img-top
+      = image_tag "download_images/#{basket.oyatsu.genre}/#{basket.oyatsu.image_url.split('/').last}", class: 'img-fluid'
+    div.card-body.card-body-style
+      h5.card-text = basket.oyatsu.name

--- a/app/views/ensokus/_ensoku.html.slim
+++ b/app/views/ensokus/_ensoku.html.slim
@@ -4,4 +4,5 @@ tr
   td.align-middle = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
   td.align-middle = ensoku.purse
   td.align-middle = ensoku.status_i18n
-  td.align-middle = link_to t('.edit'), '#', class: 'btn btn-sm btn-outline-light'
+  td.align-middle = link_to t('.see'), ensoku_path(ensoku), class: 'btn btn-sm btn-outline-light'
+  td.align-middle = link_to t('.edit'), edit_ensoku_path(ensoku), class: 'btn btn-sm btn-outline-light'

--- a/app/views/ensokus/index.html.slim
+++ b/app/views/ensokus/index.html.slim
@@ -7,9 +7,10 @@ div.main-wrapper.main-bg.main-bg-img
         thead
           tr
             th scope='col' = t('.number')
-            th scope='col' = t('.comment')
-            th scope='col' = t('.purse')
-            th scope='col' = t('.status')
+            th scope='col' = Ensoku.human_attribute_name(:comment)
+            th scope='col' = Ensoku.human_attribute_name(:purse)
+            th scope='col' = Ensoku.human_attribute_name(:status)
+            th scope='col' = t('.show')
             th scope='col' = t('.edit')
         tbody
           = render @ensokus

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -1,12 +1,10 @@
 - content_for :title
 div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    // TODO: ロゴ画像
-    // = link_to
     h1.mt-3.mb-3.font-weight-normal = t('.title')
-    div
-      = link_to t('.new'), users_ensokus_path, method: :post,  class: 'btn btn-outline-light mt-3 btn-lg'
+    div.mt-3
+      = link_to t('.new'), users_ensokus_path, method: :post,  class: 'btn btn-outline-light btn-lg'
     - if current_user.ensokus.present?
-      div
-        = link_to t('.continue'), users_ensokus_path, class: 'btn btn-outline-light mt-3 btn-lg'
+      div.mt-3
+        = link_to t('.continue'), users_ensokus_path, class: 'btn btn-outline-light btn-lg'
     = render 'shared/how_to_play'

--- a/app/views/ensokus/show.html.slim
+++ b/app/views/ensokus/show.html.slim
@@ -1,0 +1,21 @@
+- content_for :title
+div.main-wrapper.main-bg.main-bg-img
+  div.main-inner-text
+    h1.mt-3.mb-3.font-weight-normal = t('.title')
+    section.columuns.mb-3
+      div.column
+        h2 = "#{Ensoku.human_attribute_name(:comment)}:"
+        h3 = @ensoku.comment.blank? ? t('.no_comment') : @ensoku.comment
+      div.column
+        h2 = "#{Ensoku.human_attribute_name(:purse)}:"
+        h3 = @ensoku.purse
+      div.column
+        h2 = "#{Ensoku.human_attribute_name(:status)}:"
+        h3 = @ensoku.status_i18n
+      div.column
+        h2 = "#{t('.choosed_oyatsu')}:"
+        - if @ensoku.basket.present?
+          = render 'choosed_oyatsu', basket: @ensoku.basket
+        - else
+          h3 = t('.nothing_choosed')
+    = link_to t('.edit'), edit_ensoku_path(@ensoku), class: 'btn btn-outline-light btn-lg' 

--- a/app/views/my_pages/show.html.slim
+++ b/app/views/my_pages/show.html.slim
@@ -3,12 +3,12 @@ div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.columns.mb-3
-      div.column.mb-3
-        h2 = User.human_attribute_name(:name) + ':'
+      div.column
+        h2 = "#{User.human_attribute_name(:name)}:"
         h3 = "#{current_user.name}"
-      div.column.mb-3
-        h2 = User.human_attribute_name(:email) + ':'
+      div.column
+        h2 = "#{User.human_attribute_name(:email)}:"
         h3 = "#{current_user.email}"
-      = link_to t('.update'), edit_my_page_path, class: 'btn btn-outline-light'
+      = link_to t('.update'), edit_my_page_path, class: 'btn btn-outline-light mt-3'
     div
       = link_to t('.see_choosed_oyatsu'), users_ensokus_path, class: 'btn btn-outline-light'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,6 +8,10 @@ ja:
         email: 'めーるあどれす'
         password: 'ぱすわーど'
         password_confirmation: 'ぱすわーど(かくにん)'
+      ensoku:
+        comment: 'こめんと'
+        purse: 'のこりのおこづかい'
+        status: 'こうかいすてーたす'
   enums:
     user:
       general: '一般'

--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -6,11 +6,18 @@ ja:
       number: 'ばんごう'
       purse: 'のこったおこづかい'
       status: 'じょうたい'
-      edit: 'こうしんする？'
+      show: 'しょうさい'
+      edit: 'つづきからえらぶ'
     new:
       title: '遠足のおやつは300円まで！'
       new: 'あたらしくえらぶ'
       continue: 'つづきからえらぶ'
+    show:
+      title: 'えらんだおやつ(しょうさい)'
+      choosed_oyatsu: 'えらんだおやつ'
+      nothing_choosed: 'なにもえらんでないよ。えらぼう！'
+      edit: 'えらびなおす'
     ensoku:
       no_comment: 'のーこめんと'
-      edit: 'こうしん'
+      see: 'みる'
+      edit: 'えらびなおす'

--- a/config/locales/views/user_sessions/ja.yml
+++ b/config/locales/views/user_sessions/ja.yml
@@ -3,5 +3,7 @@ ja:
     new:
       title: '遠足のおやつは300円まで！'
     create:
-      success: 'ろぐいんしたよ。'
-      failure: 'ろぐいんしっぱい！もういちどためしてみてね。'
+      success: 'ろぐいんしたよ'
+      failure: 'ろぐいんしっぱい！もういちどためしてみてね'
+    destroy:
+      logout: 'ろぐあうとしたよ'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,15 +6,14 @@ Rails.application.routes.draw do
   delete  'logout',         to: 'user_sessions#destroy'
   get     '/choose_oyatsu', to: 'oyatsus#index'
 
-  resource :my_page, only: %i[show edit update]
-  resources :password_resets, only: %i[new create edit update]
-
-
   resource :users, only: %i[index new create] do
     resources :ensokus, shallow:true  do
       resources :baskets, only: %i[index show new create destroy], shallow: true
     end
   end
+
+  resource :my_page, only: %i[show edit update]
+  resources :password_resets, only: %i[new create edit update]
 
   namespace :admin do
     root              to: 'dashboards#index'


### PR DESCRIPTION
# **概要**

えらんだおやつ(詳細)画面を追加しました。
それに伴いえらんだおやつ(一覧)の文言を修正しました。
application.scssに修正を追加した結果、同様の処理がmy_pageにあったのでそちらでも変更を適用しています。

# **影響範囲**

- えらんだおやつ(詳細)
- えらんだおやつ(一覧)
- マイページ

# **確認方法**

1. えらんだおやつ(一覧)画面から詳細画面に飛べることを確認してください。
2. マイページの画面が崩れていないか確認してください。
 
# **チェックリスト**
- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**
editに関しては別イシューで対応します。