### PR TITLE
Fix: おやつを正しく保存できるように修正。

### DIFF
--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -2,15 +2,20 @@ class BasketsController < ApplicationController
   def create
     @ensoku = Ensoku.find(params[:ensoku_id])
     @oyatsu = Oyatsu.find(params[:oyatsu_id])
-    @ensoku.basket_in(@oyatsu)
-    redirect_to choose_oyatsu_path ensoku: @ensoku
+    if @ensoku.purse_under_zero?
+      redirect_to choose_oyatsu_path ensoku: @ensoku, flash: { notice: 'ng' }
+    else
+      @ensoku.basket_in(@oyatsu)
+      @ensoku.update_purse
+      redirect_to choose_oyatsu_path ensoku: @ensoku, flash: { notice: 'ok' }
+    end
   end
 
   def destroy
     basket = Basket.find(params[:id])
     @ensoku = basket.ensoku
-    @oyatsu = basket.oyatsu
     basket.destroy!
-    redirect_to choose_oyatsu_path ensoku: @ensoku
+    @ensoku.update_purse
+    redirect_to choose_oyatsu_path ensoku: @ensoku, flash: { notice: 'ok' }
   end
 end

--- a/app/helpers/baskets_helper.rb
+++ b/app/helpers/baskets_helper.rb
@@ -1,13 +1,3 @@
 # basket_controllerで使うview表示系メソッド
 module BasketsHelper
-  # 残金判定メソッド
-  def calculation
-    user_baskets = current_user.baskets
-    oyatsu_sum = []
-    user_baskets.each do |ub|
-      single_oyatsu_sum = ub.oyatsu.price * ub.quantity
-      oyatsu_sum.push single_oyatsu_sum
-    end
-    current_user.purse = current_user.purse - oyatsu_sum.sum
-  end
 end

--- a/app/helpers/ensoku_helper.rb
+++ b/app/helpers/ensoku_helper.rb
@@ -1,14 +1,2 @@
 module EnsokuHelper
-  # 遠足のおやつは300円まで
-  OKOZUKAI = 300
-
-  def calc_okozukai
-    sum = 0
-    baskets = @ensoku.baskets
-    baskets.each do |basket|
-      oyatsu = basket.oyatsu
-      sum += oyatsu.price
-    end
-    OKOZUKAI - sum
-  end
 end

--- a/app/javascript/packs/oyatsus/card.js.erb
+++ b/app/javascript/packs/oyatsus/card.js.erb
@@ -1,11 +1,11 @@
 function plusClick(){
   msg = this.dataset.oyatsuName + "をふやしたよ！";
-  alert(msg);
+  //alert(msg);
 }
 
 function minusClick(){
   msg = this.dataset.oyatsuName + "をへらしたよ！";
-  alert(msg);
+  //alert(msg);
 }
 
 window.addEventListener('DOMContentLoaded', function(){

--- a/app/models/ensoku.rb
+++ b/app/models/ensoku.rb
@@ -17,15 +17,40 @@ class Ensoku < ApplicationRecord
     open: 2
   }
 
+  OKOZUKAI = 300
+
+  # 遠足に紐づくバスケットに指定したおやつを入れる
   def basket_in(oyatsu)
+    # おこづかいよりおやつの値段が少なかったらfalse
     basket_oyatsus << oyatsu
   end
 
+  # 遠足に紐づくバスケットに指定したおやつが入っているか
   def basket_oyatsu_exists?(oyatsu)
     baskets.where(oyatsu_id: oyatsu).exists?
   end
 
+  # 遠足に紐づくバスケットから指定したおやつのデータを一つ取得する
+  # バスケットからおやつを削除するとき用
   def basket_find(oyatsu)
     baskets.find_by(oyatsu_id: oyatsu)
+  end
+
+  # 遠足に紐づくバスケットの合計金額を取得
+  def basket_price_sum
+    arr = []
+    basket_oyatsus.each do |bo|
+      arr.push bo.price
+    end
+    arr.sum
+  end
+
+  def purse_under_zero?
+    purse.negative? || purse.zero?
+  end
+
+  def update_purse
+    result = OKOZUKAI - basket_price_sum
+    update(purse: result)
   end
 end

--- a/app/views/ensokus/_okozukai.html.slim
+++ b/app/views/ensokus/_okozukai.html.slim
@@ -1,2 +1,2 @@
 h5.okozukai
-   = "#{t('.purse')}: #{calc_okozukai} 円"
+   = "#{t('.purse')}: #{@ensoku.purse} 円"

--- a/app/views/ensokus/show.html.slim
+++ b/app/views/ensokus/show.html.slim
@@ -13,8 +13,8 @@ div.main-wrapper.main-bg.main-bg-img
         = link_to t('.edit'), edit_ensoku_path(@ensoku), class: 'btn btn-outline-light btn-lg'
     div.columuns.mb-3
       h2 = "#{t('.choosed_oyatsu')}:"
-      - if @ensoku.basket.present?
-        = render 'choosed_oyatsu', basket: @ensoku.basket
+      - if @ensoku.baskets.present?
+        = render partial: 'choosed_oyatsu', collection: @ensoku.baskets, as: :basket
       - else
         h3 = t('.nothing_choosed')
       div

--- a/app/views/oyatsus/index.html.slim
+++ b/app/views/oyatsus/index.html.slim
@@ -3,6 +3,8 @@
 - if @oyatsus.present?
   div.main-wrapper.oyatsus-bg.main-bg-img
     div.container
+      - if flash[:notice]
+        = flash[:notice]
       div.row
         = render @oyatsus
       = paginate @oyatsus


### PR DESCRIPTION
# **概要**

おやつ選択画面にて、ボタンの+-が正しく動作するようにバグを修正しました。
また、Ensoku詳細画面のバグ修正も行いました。

# **影響範囲**

おやつ選択画面

# **確認方法**

1. おやつ選択画面でおやつを追加出来ることを確認してください。また、その際におこづかいの残高が増減することを確認してください。
2.  選んだおやつの詳細画面が表示されることを確認してください。なお、画面が崩れていますがこれは別で対応します。

# **チェックリスト**

- [ ] 対応するIssueを作成した
- [ ] Lint のチェックをパスした
- [ ] 確認方法の内容を満たした

# **コメント**
おやつの詳細画面はおやつ選択結果画面から修正するのこのPRでは扱いません。
