### PR TITLE
Fix: おやつ選択結果が正しく表示できるように修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,6 +57,11 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
   color: white;
 }
 
+.center-and-white {
+  text-align: center;
+  color: white;
+}
+
 // navbarの背景色を変更
 header .navbar-dark{
   background-image: linear-gradient(-60deg, #ff5858 0%, #f09819 100%);

--- a/app/views/baskets/_submit.html.slim
+++ b/app/views/baskets/_submit.html.slim
@@ -1,4 +1,4 @@
 div.basket_info
-  = link_to '#', class: 'btn btn-outline-light'
+  = link_to edit_ensoku_path(@ensoku), class: 'btn btn-outline-light'
     i.fa-solid.fa-basket-shopping
     = " #{t('.register')}"

--- a/app/views/ensokus/_data.html.slim
+++ b/app/views/ensokus/_data.html.slim
@@ -1,0 +1,8 @@
+div.mt-3.mb-1 = "#{Ensoku.human_attribute_name(:comment)}:"
+h3 = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
+div.mt-3.mb-1= "#{Ensoku.human_attribute_name(:status)}:"
+h3 = ensoku.status_i18n
+div.mt-3.mb-1 = "#{Ensoku.human_attribute_name(:purse)}:"
+h3 = "#{ensoku.purse} #{t('.yen')}"
+div.mt-3.mb-3 = link_to t('.rechoose'), choose_oyatsu_path(ensoku: ensoku), class: 'btn btn-outline-light'
+div.mb-3 = link_to t('.index'), users_ensokus_path, class: 'btn btn-outline-light'

--- a/app/views/ensokus/_form.html.slim
+++ b/app/views/ensokus/_form.html.slim
@@ -1,0 +1,11 @@
+section.form-box.border
+  = form_with model: ensoku, method: :patch, local: true do |f|
+    - if ensoku.errors.any?
+      = render 'shared/error_messages', object: f.object
+    div.form-group
+      h5 = f.label :comment, Ensoku.human_attribute_name(:comment)
+      = f.text_field :comment, class: 'form-control', placeholder: t('.comment')
+    div.form-group
+      h5 = f.label :status, Ensoku.human_attribute_name(:status)
+      = f.select :status, Ensoku.statuses_i18n.invert, class: 'form-control', placeholder: t('.ensoku')
+    = f.submit t('.submit'), class: 'btn btn-light'

--- a/app/views/ensokus/_okozukai.html.slim
+++ b/app/views/ensokus/_okozukai.html.slim
@@ -1,2 +1,2 @@
 h5.okozukai
-   = "#{t('.purse')}: #{@ensoku.purse} 円"
+  = "#{t('.purse')}: #{@ensoku.purse} #{t('.yen')}"

--- a/app/views/ensokus/edit.html.slim
+++ b/app/views/ensokus/edit.html.slim
@@ -1,18 +1,17 @@
-- content_for :title
-div.main-wrapper.main-bg.main-bg-img
-  div.main-inner-text
-    h1.mt-3.mb-3.font-weight-normal = t('.title')
-    section.form-box.border
-      = form_with model: @ensoku, local: true do |f|
-        - if @ensoku.errors.any?
-          = render 'shared/error_messages', object: f.object
-        div.form-group
-          h5 = f.label :comment, Ensoku.human_attribute_name(:comment)
-          = f.text_field :comment, class: 'form-control', placeholder: t('.comment')
-        div.form-group
-          h5 = f.label :status, Ensoku.human_attribute_name(:status)
-          = f.select :status, Ensoku.statuses_i18n.invert, class: 'form-control', placeholder: t('.ensoku')
-        = f.submit t('.submit'), class: 'btn btn-light'
-    div.mt-3
-      = link_to t('.show'), @ensoku, class: 'btn btn-outline-light btn-lg'
+- content_for :title, t('.title')
+- if @ensoku.basket_oyatsus
+  div.main-wrapper.oyatsus-bg.main-bg-img
+    div.container
+      div.row
+        div.col.mt-3.mb-3.center-and-white
+          h1.font-weight-normal = t('.title')
+          = render 'form', ensoku: @ensoku
+          = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'
+      div.row
+        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
+- else
+  div.main-wrapper.main-bg.main-bg-img
+    div.main-inner-text
+      h1.mt-3.mb-3.font-weight-normal = t('.no_result')
+      = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'
 

--- a/app/views/ensokus/index.html.slim
+++ b/app/views/ensokus/index.html.slim
@@ -11,6 +11,6 @@ div.main-wrapper.main-bg.main-bg-img
             th scope='col' = Ensoku.human_attribute_name(:status)
             th scope='col' = Ensoku.human_attribute_name(:purse)
             th scope='col' = t('.show')
-            th scope='col' = t('.again')
+            th scope='col' = t('.rechoose')
         tbody
           = render @ensokus

--- a/app/views/ensokus/show.html.slim
+++ b/app/views/ensokus/show.html.slim
@@ -1,28 +1,12 @@
-- content_for :title
-div.main-wrapper.main-bg.main-bg-img
-  div.main-inner-text
-    h1.mt-3.mb-3.font-weight-normal = t('.title')
-    div.columuns.mb-3
-      div.column
-        h2 = "#{Ensoku.human_attribute_name(:comment)}:"
-        h3 = @ensoku.comment.blank? ? t('.no_comment') : @ensoku.comment
-      div.column
-        h2 = "#{Ensoku.human_attribute_name(:status)}:"
-        h3 = @ensoku.status_i18n
-      div.column
-        = link_to t('.edit'), edit_ensoku_path(@ensoku), class: 'btn btn-outline-light btn-lg'
-    div.columuns.mb-3
-      h2 = "#{t('.choosed_oyatsu')}:"
-      - if @ensoku.baskets.present?
-        = render partial: 'choosed_oyatsu', collection: @ensoku.baskets, as: :basket
-      - else
-        h3 = t('.nothing_choosed')
-      div
-        h2 = "#{Ensoku.human_attribute_name(:purse)}:"
-        h3 = @ensoku.purse
-      div
-        = link_to t('.again'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light btn-lg'
-    div
-      = link_to t('.index'), users_ensokus_path, class: 'btn btn-light btn-lg'
-    div.mt-5
-      = link_to t('.delete'), ensoku_path(@ensoku), method: :delete, class: 'btn btn-danger btn-sm', data: {confirm: t('.really')}
+- content_for :title, t('.title')
+div.main-wrapper.oyatsus-bg.main-bg-img
+  div.container
+    div.row
+      div.col.mt-3.mb-3.center-and-white
+        h1.font-weight-normal = t('.title')
+        = render 'data', ensoku: @ensoku
+    div.row
+      - if @ensoku.basket_oyatsus
+        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
+      div.col.mt-3.mb-3.center-and-white
+        div = link_to t('.delete'), ensoku_path(@ensoku), method: :delete, class: 'btn btn-outline-danger btn-sm', data: {confirm: t('.really')}

--- a/app/views/oyatsus/_oyatsu.html.slim
+++ b/app/views/oyatsus/_oyatsu.html.slim
@@ -4,13 +4,14 @@ div.col-4.col-lg-2.mb-4 id="oyatsu-id-#{oyatsu.id}"
       = image_tag "download_images/#{oyatsu.genre}/#{oyatsu.image_url.split('/').last}", class: 'img-fluid'
     div.card-body.card-body-style
       h5.card-text = oyatsu.name
-    ul.list-group.list-group-flush
-      li.list-group-item = "#{oyatsu.price}円"
-    div.card-footer
-      div.row
-         - if @ensoku.basket_oyatsu_exists?(oyatsu)
-           = render 'oyatsus/minus_button', oyatsu: oyatsu
-         = render 'oyatsus/plus_button', oyatsu: oyatsu
+    - if current_page?(choose_oyatsu_path)
+      ul.list-group.list-group-flush
+        li.list-group-item = "#{oyatsu.price} #{t('.yen')}"
+      div.card-footer
+        div.row
+           - if @ensoku.basket_oyatsu_exists?(oyatsu)
+             = render 'oyatsus/minus_button', oyatsu: oyatsu
+           = render 'oyatsus/plus_button', oyatsu: oyatsu
 
 //    header.modal-card-head
       p.modal-card-title.has-text-centered #{oyatsu.name}

--- a/app/views/oyatsus/index.html.slim
+++ b/app/views/oyatsus/index.html.slim
@@ -3,8 +3,6 @@
 - if @oyatsus.present?
   div.main-wrapper.oyatsus-bg.main-bg-img
     div.container
-      - if flash[:notice]
-        = flash[:notice]
       div.row
         = render @oyatsus
       = paginate @oyatsus

--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -7,34 +7,39 @@ ja:
       purse: 'のこったおこづかい'
       status: 'じょうたい'
       show: 'しょうさい'
-      again: 'つづきからえらぶ'
+      rechoose: 'えらびなおす'
     new:
       title: '遠足のおやつは300円まで！'
       new: 'あたらしくえらぶ'
       continue: 'つづきからえらぶ'
     show:
-      title: 'えらんだおやつ(しょうさい)'
+      title: 'えらんだおやつ！'
       choosed_oyatsu: 'えらんだおやつ'
       nothing_choosed: 'なにもえらんでないよ。えらぼう！'
       edit: 'せっていへんこう'
-      again: 'えらびなおす'
-      index: 'いちらんにもどる'
       delete: 'けしちゃう'
       really: 'ほんとうにだいじょうぶ？'
     edit:
-      title: 'えらんだおやつのせっていへんこう'
+      title: 'おやつをかくにん！'
       comment: 'こめんとしてね！'
       status: 'すてーたす'
       submit: 'こうしん'
-      show: 'しょうさいにもどる'
+      rechoose: 'えらびなおす'
     update:
       success: 'こうしんしたよ！'
       failure: 'こうしんしっぱい。もう一度ためしてみてね。'
     destroy:
-      success: 'けしたよ'
+      success: 'けしたよー'
     ensoku:
       no_comment: 'のーこめんと'
       see: 'みる'
-      again: 'えらびなおす'
+      again: 'そうする'
     okozukai:
       purse: 'のこり'
+      yen: 'えん'
+    data:
+      rechoose: 'えらびなおす'
+      index: 'いちらんにもどる'
+      yen: 'えん'
+    form:
+      submit: 'おっけー！'

--- a/config/locales/views/oyatsus/ja.yml
+++ b/config/locales/views/oyatsus/ja.yml
@@ -4,6 +4,9 @@ ja:
       title: 'おやつをえらぶ'
       no_result: 'みつからないよ！'
       seach_again: 'もういちど、けんさくしてみてね。'
+      yen: 'えん'
     search_form:
       word: 'おやつのなまえをいれてね'
       submit: 'しらべる'
+    oyatsu:
+      yen: 'えん'


### PR DESCRIPTION
# **概要**

おやつ選択結果が正しく表示できるように修正

# **影響範囲**

おやつ選択結果
おやつ編集

# **確認方法**

1. おやつ一覧画面から「おかいけい」ボタンを押下し、選択結果の入力画面に遷移することを確認
2. おやつ編集画面から遷移結果を編集できることを確認 

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした