### PR TITLE
Fix: ヘッダーの表示ズレを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,17 +22,14 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import "./oyatsus.scss";
 @import "./ensokus.scss";
 
+
 .main-wrapper {
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-align: center;
   align-items: center;
-  padding-top: 40px;
-  padding-bottom: 40px;
 }
 
 .main-bg {
-  height: calc(100vh - 134px);
+  height: 100vh;
   position: relative;
   background-size: cover;
 }
@@ -50,8 +47,6 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 
 .main-inner-text {
   position: absolute;
-  //top: 50%;
-  //left: 50%;
   width: 100%;
   text-align: center;
   color: white;
@@ -62,9 +57,17 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
   color: white;
 }
 
-// navbarの背景色を変更
-header .navbar-dark{
-  background-image: linear-gradient(-60deg, #ff5858 0%, #f09819 100%);
+// ヘッダー要素
+.header {
+  height: 1rem;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  z-index: 9999;
+  // navbarの背景色を変更
+  .navbar-dark{
+    background-image: linear-gradient(-60deg, #ff5858 0%, #f09819 100%);
+  }
 }
 .navbar-expand-lg .navbar-collapse {
     justify-content: right;
@@ -80,9 +83,10 @@ header .navbar-dark{
   color: $light;
 }
 
-// footerの背景色を変更
-footer {
+// フッター要素
+.footer {
   background-image: linear-gradient(-60deg, #ff5858 0%, #f09819 100%);
+  text-align: center;
 }
 
 // _reboot.scssに対処できないため!importantで指定

--- a/app/assets/stylesheets/oyatsus.scss
+++ b/app/assets/stylesheets/oyatsus.scss
@@ -5,7 +5,8 @@
 .oyatsus-bg {
   position: relative;
   background-size: cover;
-  min-height: 100vh
+  padding-top: 10vh;
+  min-height: 100vh;
 }
 
 .oyatsus-bg:before {

--- a/app/views/baskets/_submit.html.slim
+++ b/app/views/baskets/_submit.html.slim
@@ -1,4 +1,3 @@
-div.basket_info
-  = link_to edit_ensoku_path(@ensoku), class: 'btn btn-outline-light'
-    i.fa-solid.fa-basket-shopping
-    = " #{t('.register')}"
+= link_to edit_ensoku_path(@ensoku), class: 'btn btn-outline-light'
+  i.fa-solid.fa-basket-shopping
+  = " #{t('.register')}"

--- a/app/views/ensokus/_okozukai.html.slim
+++ b/app/views/ensokus/_okozukai.html.slim
@@ -1,2 +1,1 @@
-h5.okozukai
-  = "#{t('.purse')}: #{@ensoku.purse} #{t('.yen')}"
+h4.okozukai = "#{t('.purse')}: #{@ensoku.purse} #{t('.yen')}"

--- a/app/views/oyatsus/index.html.slim
+++ b/app/views/oyatsus/index.html.slim
@@ -3,11 +3,16 @@
 - if @oyatsus.present?
   div.main-wrapper.oyatsus-bg.main-bg-img
     div.container
+      div.mt-3.mb-3
+        = render 'oyatsus/search_form', q: @q, url: choose_oyatsu_path(ensoku: @ensoku)
       div.row
         = render @oyatsus
       = paginate @oyatsus
 - else
   div.main-wrapper.main-bg.main-bg-img
     div.main-inner-text
-      h1.mt-3.mb-3.font-weight-normal = t('.no_result')
-      h3.mt-3.mb-3.font-weight-normal = t('.seach_again')
+      div.container
+        div.mx-3
+          = render 'oyatsus/search_form', q: @q, url: choose_oyatsu_path(ensoku: @ensoku)
+        h1.mt-3.mb-3.font-weight-normal = t('.no_result')
+        h3.mt-3.mb-3.font-weight-normal = t('.seach_again')

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,5 +1,5 @@
 / TODO: リンクの追加
-footer.mt-auto.text-center.text-lg-start.test-muted
+footer.footer.mt-auto.text-lg-start
   section.d-flex.justify-content-center.p-4
     div
       = link_to '#', id: 'twitter', class: 'link-light'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,4 +1,4 @@
-header
+header.header
   nav.navbar.navbar-dark
     div.container-fluid.row
       - if logged_in?

--- a/app/views/shared/_login_header.html.slim
+++ b/app/views/shared/_login_header.html.slim
@@ -1,17 +1,15 @@
-div.col-2
+div.col
   div.row
-    div.col-4
+    div.col
       = link_to root_path, class: 'navbar-brand'
         = image_tag "logo_transparent.png", size: '60x60'
-    div.col-8.d-flex.justify-content-center.align-items-center
+    div.col.d-flex.justify-content-center.align-items-center
       - if current_page?(choose_oyatsu_path)
         = render 'ensokus/okozukai'
-div.col-8
-  - if current_page?(choose_oyatsu_path)
-    div
-      = render 'oyatsus/search_form', q: @q, url: choose_oyatsu_path(ensoku: @ensoku)
-div.col-1.d-flex.justify-content-center.align-items-center
-  - if current_page?(choose_oyatsu_path)
-    = render 'baskets/submit'
-div.col-1.text-end
-  = render 'shared/toggle'
+div.col
+  div.row
+    div.col.d-flex.justify-content-center.align-items-center
+      - if current_page?(choose_oyatsu_path)
+        = render 'baskets/submit'
+    div.col.text-end
+      = render 'shared/toggle'

--- a/app/views/shared/_logout_header.html.slim
+++ b/app/views/shared/_logout_header.html.slim
@@ -1,8 +1,6 @@
 div.col
   = link_to root_path, class: 'navbar-brand'
     = image_tag "logo_transparent.png", size: '60x60'
-    div.col.text-end
-      - unless current_page?(root_path)
-        = link_to t('.login'), root_path, class: 'btn btn-outline-light mx-3'
-      - unless current_page?(new_users_path)
-        = link_to t('.new_registration'), new_users_path, class: 'btn btn-outline-light'
+div.col.text-end
+  - unless current_page?(root_path)
+    = link_to t('.login'), root_path, class: 'btn btn-outline-light'

--- a/app/views/user_sessions/_login_form.html.slim
+++ b/app/views/user_sessions/_login_form.html.slim
@@ -1,17 +1,16 @@
 section.form-box.border
   // TODO: twitterログイン
-  div.twitter-box
+  //div.twitter-box
     p.border-bottom ツイッターログイン
   = form_with url: login_path, local: true do |f|
     div.form-group
-      = f.label :email, t('.email')
-      = f.email_field :email, id: 'email', class: 'form-control', blaceholder: 'email'
+      = f.label :email, User.human_attribute_name(:email)
+      = f.email_field :email, id: 'email', class: 'form-control',placeholder: t('.email')
     div.field.has-text-centered
-      = f.label :password, t('.password'), for: 'password'
-      = f.password_field :password, id: 'password', class: 'form-control', blaceholder: 'email'
-    /= f.submit t('.login'), class: 'btn btn-primary' TODO言語対応
-    = f.submit 'ろぐいん', class: 'btn btn-outline-light'
+      = f.label :password, User.human_attribute_name(:password)
+      = f.password_field :password, id: 'password', class: 'form-control', placeholder: t('.password')
+    = f.submit t('.submit'), class: 'btn btn-outline-light'
 div
-  = link_to 'しんきとうろく', new_users_path, class: 'btn btn-outline-light mt-3'
+  = link_to t('.new_registration'), new_users_path, class: 'btn btn-outline-light mt-3'
 div
-  = link_to 'ぱすわーどわすれちゃった', new_password_reset_path, class: 'btn btn-outline-light mt-3'
+  = link_to t('.forgot_password'), new_password_reset_path, class: 'btn btn-outline-light mt-3'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,6 +1,7 @@
 - content_for :title
 div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    h1.mt-3.mb-3.font-weight-normal = t('.title')
+    = image_tag "logo_transparent.png", size: '300x300'
+    h1.mb-3.font-weight-normal = t('.title')
     = render 'login_form'
     = render 'shared/how_to_play'

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,7 +1,6 @@
 - content_for :title, t('.title')
 div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
-    = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')
     section.form-box.border
       = render 'form', user: @user

--- a/config/locales/views/shared/ja.yml
+++ b/config/locales/views/shared/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  shared:
+    logout_header:
+      login: 'ろぐいん'

--- a/config/locales/views/user_sessions/ja.yml
+++ b/config/locales/views/user_sessions/ja.yml
@@ -7,3 +7,9 @@ ja:
       failure: 'ろぐいんしっぱい！もういちどためしてみてね'
     destroy:
       logout: 'ろぐあうとしたよ'
+    login_form:
+      email: 'めーるあどれす'
+      password: 'ぱすわーど'
+      submit: 'ろぐいん'
+      new_registration: 'しんきとうろく'
+      forgot_password: 'ぱすわーどわすれちゃった'


### PR DESCRIPTION
# **概要**

おやつ選択画面において、検索窓のサイズを固定にしてた影響からヘッダーのレイアウトが崩れていたので修正

# **影響範囲**

全般
おやつ選択画面のレイアウトを修正した際に、全般への影響が発生したため。

# **確認方法**

1. ログアウトした状態でトップ画面に遷移
2. ログインした状態でトップ画面に遷移
3. おやつ一覧画面にて、スクロールに合わせてヘッダーが動くことを確認

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**
後々に再度修正する可能性あり。