### PR TITLE
Update: ヘッダーとメインのcssの関係を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,9 +29,18 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 }
 
 .main-bg {
-  height: 100vh;
   position: relative;
   background-size: cover;
+  padding-top: 10vh;
+  min-height: 100vh;
+}
+
+.main-bg#top {
+  position: relative;
+  background-size: cover;
+  height: 120vh;
+  padding-top: 10vh;
+  min-height: 100vh;
 }
 
 .main-bg:before {
@@ -50,6 +59,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
   width: 100%;
   text-align: center;
   color: white;
+  padding-bottom: 10vh;
 }
 
 .center-and-white {
@@ -59,7 +69,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 
 // ヘッダー要素
 .header {
-  height: 1rem;
+  height: 100px;
   width: 100%;
   position: fixed;
   top: 0;
@@ -86,7 +96,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 // フッター要素
 .footer {
   background-image: linear-gradient(-60deg, #ff5858 0%, #f09819 100%);
-  text-align: center;
+  width: 100%;
 }
 
 // _reboot.scssに対処できないため!importantで指定

--- a/app/views/ensokus/index.html.slim
+++ b/app/views/ensokus/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title
 div.main-wrapper.main-bg.main-bg-img
-  div.main-inner-text.p-5
+  div.main-inner-text.px-5
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     div.table-responsive.text-nowrap
       table.table

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg.main-bg-img id = 'top'
   div.main-inner-text
     = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')


### PR DESCRIPTION
# **概要**

ヘッダーとメインのcssの関係を修正しました。

# **影響範囲**

ログイン・未ログインにおけるトップページ
main-bgが関わるview全般

# **確認方法**

1. ログインしている状態でトップ画面に遷移しロゴとヘッダーが重なっていないことを確認してください。
2. ログインしていない状態でmain-bgに遷移しロゴとヘッダーが重なっていないことを確認してください。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした
