### PR TITLE
Fix: おやつをかくにん画面のコメント入力のプレースホルダーがi18n対応されていないので対応

### DIFF
--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -45,3 +45,4 @@ ja:
       no_comment: 'のーこめんと'
     form:
       submit: 'おっけー！'
+      comment: 'こめんとしてね'


### PR DESCRIPTION
# **概要**

おやつをかくにん画面のコメント入力のプレースホルダーがi18n対応されていないので対応

# **コメント**

軽微な修正のため各項目は省略。