### PR TITLE
Change: ユーザー未ログイン時の挙動を変更

### DIFF
--- a/app/controllers/ensokus_controller.rb
+++ b/app/controllers/ensokus_controller.rb
@@ -1,6 +1,6 @@
 class EnsokusController < ApplicationController
   before_action :set_ensoku, only: %i[show edit update destroy]
-  before_action :check_request, only: %i[edit update destroy]
+  before_action :check_request, only: %i[show edit update destroy]
 
   # 遠足一覧画面
   # Userの全遠足結果を取得
@@ -15,13 +15,19 @@ class EnsokusController < ApplicationController
   # 新規遠足作成
   def create
     @ensoku = Ensoku.create
+    # ログインしない場合のためにsessionを登録
+    session.clear if session.present?
+    session[:ensoku_id] = @ensoku.id
     redirect_to choose_oyatsu_path(ensoku: @ensoku)
   end
 
+  # おかし選択結果
   def show; end
 
+  # 選択結果のステータス編集
   def edit; end
 
+  # 選択結果のステータス更新
   def update
     if @ensoku.update(ensoku_params)
       redirect_to @ensoku, success: t('.success')

--- a/app/controllers/oyatsus_controller.rb
+++ b/app/controllers/oyatsus_controller.rb
@@ -26,11 +26,12 @@ class OyatsusController < ApplicationController
   end
 
   def set_ensoku
-    if params[:ensoku].present?
-      @ensoku = Ensoku.find(params[:ensoku])
-    # 検索時にsearch_form_forでparamsを渡せないのでhiddenで渡す
-    elsif params[:q][:ensoku].present?
-      @ensoku = Ensoku.find(params[:q][:ensoku])
+    # セッション情報がある場合
+    if session[:ensoku_id].present?
+      @ensoku = Ensoku.find(session[:ensoku_id])
+    # セッション情報がない場合
+    elsif params[:ensoku].preset?
+      @ensoku = Ensoku.find(:ensoku)
     else
       redirect_to new_ensoku_path
     end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,14 +2,15 @@ class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create], raise: false
 
   def new
-    redirect_to new_users_ensoku_path if logged_in?
+    redirect_to ensokus_path if logged_in?
   end
 
   def create
     @user = login(params[:email], params[:password])
-
     if @user
-      redirect_back_or_to new_users_ensoku_path, success: t('.success')
+      binding.pry
+      set_ensoku_user if session[:ensoku_id].present?
+      redirect_back_or_to ensokus_path, success: t('.success')
     else
       flash.now[:danger] = t('.failure')
       render 'new'
@@ -19,5 +20,14 @@ class UserSessionsController < ApplicationController
   def destroy
     logout
     redirect_to root_path, success: t('.logout')
+  end
+
+  private
+
+  def set_ensoku_user
+    # 遠足のセッション情報が存在する場合、ユーザーと紐付けて登録
+    @ensoku = Ensoku.find(session[:ensoku_id])
+    @ensoku.user_id = @user.id
+    @ensoku.save
   end
 end

--- a/app/views/ensokus/edit.html.slim
+++ b/app/views/ensokus/edit.html.slim
@@ -3,12 +3,14 @@
   div.main-wrapper.main-bg.main-bg-img
     div.container
       div.row
-        div.col.mt-3.mb-3
-          h1.font-weight-normal.center-and-white.mb-3 = t('.title')
-          = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
-          div.text-center = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'
+        div.col.mt-3.mb-3.center-and-white
+          h1 = t('.title')
+          h2 = render 'okozukai'
+      div.row
+        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
       div.row
         div.col.center-and-white
+          = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'
           = render 'edit_form', ensoku: @ensoku
 - else
   div.main-wrapper.main-bg.main-bg-img

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -3,9 +3,9 @@ div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
     = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')
-    div.mt-3
-      = link_to t('.new'), ensokus_path, method: :post,  class: 'btn btn-outline-light btn-lg'
+    div.mt-3 = link_to t('.new'), ensokus_path, method: :post, class: 'btn btn-outline-light btn-lg'
+    - if session[:ensoku_id].present?
+      div.mt-3 = link_to t('.continue'), choose_oyatsu_path(session[:ensoku]), class: 'btn btn-outline-light btn-lg'
     - if logged_in? && current_user.ensokus.present?
-      div.mt-3
-        = link_to t('.continue'), ensokus_path, class: 'btn btn-outline-light btn-lg'
+      div.mt-3 = link_to t('.index'), ensokus_path, class: 'btn btn-outline-light btn-lg'
     div.mt-5 = render 'shared/how_to_play'

--- a/app/views/ensokus/show.html.slim
+++ b/app/views/ensokus/show.html.slim
@@ -24,5 +24,6 @@ div.main-wrapper.main-bg.main-bg-img
         - if logged_in?
           div.mb-3.text-center = link_to t('.index'), ensokus_path, class: 'btn btn-outline-light'
         - else
-        div.center-and-white.mb-3 = render 'shared/registry_merit'
-        div.mb-3.text-center = link_to t('.new_registry'), '#', class: 'btn btn-outline-light'
+          div.center-and-white.mb-3 = render 'shared/registry_merit'
+          div.mb-3.text-center = link_to t('.new_registry'), new_users_path, class: 'btn btn-outline-light'
+          div.mb-3.text-center = link_to t('.login'), login_path, class: 'btn btn-outline-light'

--- a/app/views/my_pages/show.html.slim
+++ b/app/views/my_pages/show.html.slim
@@ -10,4 +10,4 @@ div.main-wrapper.main-bg.main-bg-img
           h2.mt-3.mb-1= "#{User.human_attribute_name(:email)}:"
           h3 = "#{current_user.email}"
       div.mb-3 = link_to t('.update'), edit_my_page_path, class: 'btn btn-outline-light mt-3'
-      div = link_to t('.see_choosed_oyatsu'), users_ensokus_path, class: 'btn btn-outline-light'
+      div = link_to t('.see_choosed_oyatsu'), ensokus_path, class: 'btn btn-outline-light'

--- a/app/views/shared/_toggle.html.slim
+++ b/app/views/shared/_toggle.html.slim
@@ -25,4 +25,4 @@ div#navbarSupportedContent.collapse.navbar-collapse.justify-content-right
       li.nav-item
          = link_to t('.everyone_oyatsu'), everyone_oyatsus_path, class: 'nav-link'
       li.nav-item
-        = link_to t('.login'), logout_path, method: 'delete', class: 'nav-link'
+        = link_to t('.login'), login_path, method: 'delete', class: 'nav-link'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -4,4 +4,3 @@ div.main-wrapper.main-bg.main-bg-img id = 'top'
     = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')
     = render 'login_form'
-    = render 'shared/how_to_play'

--- a/config/locales/views/ensokus/ja.yml
+++ b/config/locales/views/ensokus/ja.yml
@@ -14,6 +14,7 @@ ja:
       title: '遠足のおやつは300円まで！'
       new: 'あたらしくえらぶ'
       continue: 'つづきからえらぶ'
+      index: 'えらんだおやつをみる'
     show:
       title: 'えらんだおやつ！'
       choosed_oyatsu: 'えらんだおやつ'
@@ -24,13 +25,13 @@ ja:
       index: 'いちらんにもどる'
       please_choose: 'おやつをえらんでね！'
       new_registry: 'かいいんとうろく'
+      login: 'ろぐいん'
     edit:
       title: 'これでいい？'
       comment: 'こめんとしてね！'
       status: 'すてーたす'
       submit: 'こうしん'
       rechoose: 'えらびなおす'
-      delete: 'けしちゃう'
       really: 'ほんとうにだいじょうぶ？'
     update:
       success: 'こうしんしたよ！'
@@ -50,3 +51,4 @@ ja:
     edit_form:
       submit: 'おっけー！'
       comment: 'こめんとしてね'
+      delete: 'けしちゃう'


### PR DESCRIPTION
# **概要**

ユーザー未ログイン時における挙動を変更しました。
主に画面遷移とsessionを用いた情報の保持を追加変更しました。

# **影響範囲**

全般

# **確認方法**

1. ユーザー未ログイン時に「はじめる」をえらんだ後に、ルート画面に戻り「つづきから」ボタンがあることを確認
2. おやつを続きから選べることを確認
3. おやつを選んだあとにログイン画面からログインした場合、選んだおやつがえらんだおやつ一覧に追加されていることを確認。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした
