### PR TITLE
Fix: おやつ一覧画面の無限スクロール

### DIFF
--- a/app/controllers/ensokus_controller.rb
+++ b/app/controllers/ensokus_controller.rb
@@ -46,7 +46,6 @@ class EnsokusController < ApplicationController
   private
 
   def set_ensoku
-    binding.pry
     @ensoku = Ensoku.find(params[:id])
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,7 +23,7 @@ import '@fortawesome/fontawesome-free'
 
 $(function() {
     $('.jscroll').jscroll({
-      loadingHtml: '読み込み中・・・', //記事読み込み中の表示
+      loadingHtml: '・・・', //記事読み込み中の表示
       autoTrigger: true, // 自動で読み込むか否か、trueで自動、falseでボタンクリックとなる。
       nextSelector: 'a.jscroll-next',  // 次ページリンクのセレクタ
       padding: 20, // 指定したコンテンツの下かた何pxで読み込むかを指定(autoTrigger: trueの場合のみ)

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -5,7 +5,7 @@ div.main-wrapper.main-bg.main-bg-img
     h1.mb-3.font-weight-normal = t('.title')
     div.mt-3 = link_to t('.new'), ensokus_path, method: :post, class: 'btn btn-outline-light btn-lg'
     - if session[:ensoku_id].present?
-      div.mt-3 = link_to t('.continue'), choose_oyatsu_path(session[:ensoku]), class: 'btn btn-outline-light btn-lg'
+      div.mt-3 = link_to t('.continue'), choose_oyatsu_path(session[:ensoku_id]), class: 'btn btn-outline-light btn-lg'
     - if logged_in? && current_user.ensokus.present?
       div.mt-3 = link_to t('.index'), ensokus_path, class: 'btn btn-outline-light btn-lg'
     div.mt-5 = render 'shared/how_to_play'

--- a/app/views/oyatsus/_oyatsu.html.slim
+++ b/app/views/oyatsus/_oyatsu.html.slim
@@ -4,7 +4,7 @@ div.col-4.col-lg-2.mb-4 id="oyatsu-id-#{oyatsu.id}"
       = image_tag "download_images/#{oyatsu.genre}/#{oyatsu.image_url.split('/').last}", class: 'img-fluid'
     div.card-body.card-body-style
       h5.card-text = oyatsu.name
-    - if current_page?(choose_oyatsu_path)
+    - if request.path.include?(choose_oyatsu_path)
       ul.list-group.list-group-flush
         li.list-group-item = "#{oyatsu.price} #{t('.yen')}"
       div.card-footer


### PR DESCRIPTION
# **概要**

「つづきからえらぶ」場合のおやつ一覧画面の無限スクロールが正しく動作できていなかったので修正。

# **影響範囲**

おやつ一覧画面

# **確認方法**

1.  「つづきからえらぶ」場合のおやつ一覧画面の無限スクロールが正しく動作できていることを確認。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした