### PR TITLE
Fix: おやつ選択結果確認画面が正しく表示され、おやつの重複が無くなるように修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,15 +32,6 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 .main-bg {
   position: relative;
   background-size: cover;
-  padding-top: 10vh;
-  min-height: 100vh;
-}
-
-.main-bg#top {
-  position: relative;
-  background-size: cover;
-  height: 120vh;
-  padding-top: 10vh;
   min-height: 100vh;
 }
 

--- a/app/models/ensoku.rb
+++ b/app/models/ensoku.rb
@@ -44,6 +44,11 @@ class Ensoku < ApplicationRecord
     arr.sum
   end
 
+  # 遠足に紐づくバスケットのおかしの種類をまとめたものを取得
+  def basket_oyatsus_group
+    basket_oyatsus.group(:id)
+  end
+
   # おこずかいが0以下になるかチェック
   def purse_under_zero?
     purse.negative? || purse.zero?

--- a/app/views/ensokus/edit.html.slim
+++ b/app/views/ensokus/edit.html.slim
@@ -7,7 +7,7 @@
           h1 = t('.title')
           h2 = render 'okozukai'
       div.row
-        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
+        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu
       div.row
         div.col.center-and-white
           = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'

--- a/app/views/ensokus/show.html.slim
+++ b/app/views/ensokus/show.html.slim
@@ -6,7 +6,7 @@ div.main-wrapper.main-bg.main-bg-img
         h1.font-weight-normal.center-and-white = t('.title')
     div.row
       - if @ensoku.basket_oyatsus.present?
-        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
+        = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu
       - else
         div.col
           h2.font-weight-normal.center-and-white = t('.please_choose')

--- a/app/views/oyatsus/_oyatsu.html.slim
+++ b/app/views/oyatsus/_oyatsu.html.slim
@@ -1,9 +1,9 @@
 div.col-4.col-lg-2.mb-4
   div.card.card-wrapper.box-shadow.h-100.text-center
-    span id = "oyatsu-id-#{oyatsu.id}-badge" = render 'badge', oyatsu: oyatsu
+    span id = "oyatsu-id-#{oyatsu.id}-badge" = render 'oyatsus/badge', oyatsu: oyatsu
     div.card-img-top = image_tag "download_images/#{oyatsu.genre}/#{oyatsu.image_url.split('/').last}", class: 'img-fluid'
     div.card-body.card-body-style
       h5.card-text = oyatsu.name
-    div.card-footer id  = "oyatsu-id-#{oyatsu.id}-purchase"
-      - if request.path.include?(choose_oyatsu_path)
+    - if request.path.include?(choose_oyatsu_path)
+      div.card-footer id  = "oyatsu-id-#{oyatsu.id}-purchase"
         = render 'oyatsu_purchase', oyatsu: oyatsu

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title
-div.main-wrapper.main-bg.main-bg-img id = 'top'
+div.main-wrapper.main-bg.main-bg-img
   div.main-inner-text
     = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')


### PR DESCRIPTION
# **概要**

おやつ選択結果確認画面が正しく表示され、おやつの重複が無くなるように修正しました。

# **影響範囲**

おやつ選択結果確認画面(edit)
おやつ選択結果画面(show)

# **確認方法**

1. 同一種類のおかしを複数選択した状態でおやつの選択結果確認画面を確認し、重複が表示されずお菓子の数がバッジで表現されていることを確認してください。
2. 同一種類のおかしを複数選択した状態でおやつの選択結果画面を確認し、重複が表示されずお菓子の数がバッジで表現されていることを確認してください。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした
