### PR TITLE
Add: 遠足管理画面を追加

### DIFF
--- a/app/controllers/admin/ensokus_controller.rb
+++ b/app/controllers/admin/ensokus_controller.rb
@@ -29,4 +29,8 @@ class Admin::EnsokusController < Admin::BaseController
   def set_ensoku
     @ensoku = Ensoku.find(params[:id])
   end
+
+  def ensoku_params
+    params.require(:ensoku).permit(:comment, :statsus)
+  end
 end

--- a/app/controllers/admin/ensokus_controller.rb
+++ b/app/controllers/admin/ensokus_controller.rb
@@ -1,0 +1,32 @@
+class Admin::EnsokusController < Admin::BaseController
+  before_action :set_ensoku, only: %i[show edit update destroy]
+
+  def index
+    @q = Ensoku.ransack(params[:q])
+    @ensokus = @q.result(distinct: true).order(created_at: :desc).page(params[:page])
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @ensoku.update(ensoku_params)
+      redirect_to admin_ensokus_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :edit
+    end
+  end
+
+  def destroy
+    @ensoku.destroy!
+    redirect_to admin_ensokus_path, success: t('.success')
+  end
+
+  private
+
+  def set_ensoku
+    @ensoku = Ensoku.find(params[:id])
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[show edit update destroy]
+
   def index
     @q = User.ransack(params[:q])
     @users = @q.result(distinct: true).order(created_at: :desc).page(params[:page])

--- a/app/models/ensoku.rb
+++ b/app/models/ensoku.rb
@@ -29,6 +29,11 @@ class Ensoku < ApplicationRecord
     baskets.where(oyatsu_id: oyatsu).exists?
   end
 
+  # 遠足に紐づくバスケットに指定したおやつがいくつ入っているか
+  def basket_oyatsu_count(oyatsu)
+    baskets.where(oyatsu_id: oyatsu).count
+  end
+
   # 遠足に紐づくバスケットから指定したおやつのデータを一つ取得する
   # バスケットからおやつを削除するとき用
   def basket_find(oyatsu)
@@ -58,5 +63,10 @@ class Ensoku < ApplicationRecord
   def update_purse
     result = OKOZUKAI - basket_price_sum
     update(purse: result)
+  end
+
+  # 遠足に紐づくユーザー名を取得
+  def user_name
+    user.present? ? user.name : ''
   end
 end

--- a/app/views/admin/ensokus/_ensoku.html.slim
+++ b/app/views/admin/ensokus/_ensoku.html.slim
@@ -1,0 +1,10 @@
+tr
+  td = ensoku.id
+  td = ensoku.user_name
+  td = ensoku.purse
+  td = ensoku.comment
+  td = ensoku.status_i18n
+  td = l ensoku.created_at, format: :long
+  td = link_to t('admin.common.button.show'), admin_ensoku_path(ensoku), class: 'btn btn-info'
+  td = link_to t('admin.common.button.edit'), edit_admin_ensoku_path(ensoku), class: 'btn btn-success'
+  td = link_to t('admin.common.button.delete'), admin_ensoku_path(ensoku), method: :delete, data: { confirm: t('.delete_confirm') }, class: 'btn btn-danger' 

--- a/app/views/admin/ensokus/_form.html.slim
+++ b/app/views/admin/ensokus/_form.html.slim
@@ -1,0 +1,10 @@
+= form_with model: ensoku, url: url, local: true do |f|
+  - if ensoku.errors.any?
+    = render 'shared/error_messages', object: f.object
+  div.form-group
+    = f.label :comment, t('admin.ensokus.common.comment')
+    = f.text_field :comment, class: 'form-control', placeholder: t('admin.ensokus.common.comment')
+  div.form-group
+    = f.label :status, Ensoku.human_attribute_name(:status)
+    = f.select :status, Ensoku.statuses_i18n.invert, {}, class: 'form-control'
+  div.text-center = f.submit t('.submit'), class: 'btn btn-primary'

--- a/app/views/admin/ensokus/_oyatsu.html.slim
+++ b/app/views/admin/ensokus/_oyatsu.html.slim
@@ -1,0 +1,4 @@
+tr
+  td = oyatsu.id
+  td = oyatsu.name
+  td = @ensoku.basket_oyatsu_count(oyatsu)

--- a/app/views/admin/ensokus/_search_form.html.slim
+++ b/app/views/admin/ensokus/_search_form.html.slim
@@ -1,0 +1,9 @@
+= search_form_for @q, url: admin_ensokus_path do |f|
+  .row
+    .form-inline.align-items-center.mx-auto
+      .col-auto
+        = f.search_field :user_name_cont, class: 'form-control', placeholder: t('admin.common.search_form.search_word')
+      .col-auto
+        = f.select :status_eq, Ensoku.statuses_i18n.invert.map{|key, value| [key, Ensoku.statuses[value]]}, { include_blank: t('admin.common.search_form.unspecified') }, { class: 'form-control mr-1' }
+      .col-auto
+        = f.submit class: 'btn btn-primary'

--- a/app/views/admin/ensokus/edit.html.slim
+++ b/app/views/admin/ensokus/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Ensokus#edit
+p Find me in app/views/admin/ensokus/edit.html.slim

--- a/app/views/admin/ensokus/edit.html.slim
+++ b/app/views/admin/ensokus/edit.html.slim
@@ -1,2 +1,7 @@
-h1 Admin::Ensokus#edit
-p Find me in app/views/admin/ensokus/edit.html.slim
+- content_for(:title, t('.title'))
+- breadcrumb :admin_ensoku, @ensoku
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1 = t('.title')
+      = render 'form', ensoku: @ensoku, url: admin_ensoku_path(@ensoku)

--- a/app/views/admin/ensokus/index.html.slim
+++ b/app/views/admin/ensokus/index.html.slim
@@ -1,0 +1,25 @@
+- content_for(:title, t('.title'))
+- breadcrumb :admin_ensokus, @ensokus
+.container.mb-5.pt-2
+  h1 = t('.title')
+  .row
+    .col-md-12.mb-3
+      = render 'search_form'
+  .row
+    .col-md-12
+      table.table.table-striped.text-center
+        thead
+          tr
+            th[scope="col"] = Ensoku.human_attribute_name(:id)
+            th[scope="col"] = t('admin.ensokus.common.user_name')
+            th[scope="col"] = t('admin.ensokus.common.purse')
+            th[scope="col"] = t('admin.ensokus.common.comment')
+            th[scope="col"] = t('admin.ensokus.common.status')
+            th[scope="col"] = Ensoku.human_attribute_name(:created_at)
+            th[scope="col"]
+            th[scope="col"]
+            th[scope="col"]
+        tbody
+          = render @ensokus
+  .row
+    .col-md-12 = paginate @ensokus

--- a/app/views/admin/ensokus/new.html.slim
+++ b/app/views/admin/ensokus/new.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Ensokus#new
+p Find me in app/views/admin/ensokus/new.html.slim

--- a/app/views/admin/ensokus/show.html.slim
+++ b/app/views/admin/ensokus/show.html.slim
@@ -1,0 +1,38 @@
+- content_for(:title, t('.title'))
+- breadcrumb :admin_ensoku, @ensoku
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1 = t('.title')
+      .text-right.mb-3
+        = link_to t('admin.common.button.edit'), edit_admin_ensoku_path(@ensoku), class: 'btn btn-success mx-3'
+        = link_to t('admin.common.button.delete'), admin_ensoku_path(@ensoku), method: :delete, data: { confirm: t('admin.ensokus.delete.delete_confirm') }, class: 'btn btn-danger'
+      h5 = t('.info')
+      table.table.table-bordered.bg-white
+        tr
+          th[scope="row"] = Ensoku.human_attribute_name(:id)
+          td = @ensoku.id
+        tr
+          th[scope="row"] = t('admin.ensokus.common.user_name')
+          td = @ensoku.user_name
+        tr
+          th[scope="row"] = t('admin.ensokus.common.purse')
+          td = @ensoku.purse
+        tr
+          th[scope="row"] = t('admin.ensokus.common.comment')
+          td = @ensoku.comment
+        tr
+          th[scope="row"] = t('admin.ensokus.common.status')
+          td = @ensoku.status_i18n
+        tr
+          th[scope="row"] = Ensoku.human_attribute_name(:created_at)
+          td = l @ensoku.created_at, format: :long
+      h5 = t('.choosed_oyatsu')
+      table.table.table-borderd.text-center.bg-white
+        thead
+          tr
+            th[scope='col'] = Oyatsu.human_attribute_name(:id)
+            th[scope='col'] = Oyatsu.human_attribute_name(:name)
+            th[scope='col'] = t('.oyatsu_count')
+        tbody
+          = render partial: 'oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu

--- a/app/views/admin/ensokus/show.html.slim
+++ b/app/views/admin/ensokus/show.html.slim
@@ -6,7 +6,7 @@
       h1 = t('.title')
       .text-right.mb-3
         = link_to t('admin.common.button.edit'), edit_admin_ensoku_path(@ensoku), class: 'btn btn-success mx-3'
-        = link_to t('admin.common.button.delete'), admin_ensoku_path(@ensoku), method: :delete, data: { confirm: t('admin.ensokus.delete.delete_confirm') }, class: 'btn btn-danger'
+        = link_to t('admin.common.button.delete'), admin_ensoku_path(@ensoku), method: :delete, data: { confirm: t('admin.ensokus.ensoku.delete_confirm') }, class: 'btn btn-danger'
       h5 = t('.info')
       table.table.table-bordered.bg-white
         tr
@@ -28,11 +28,14 @@
           th[scope="row"] = Ensoku.human_attribute_name(:created_at)
           td = l @ensoku.created_at, format: :long
       h5 = t('.choosed_oyatsu')
-      table.table.table-borderd.text-center.bg-white
-        thead
-          tr
-            th[scope='col'] = Oyatsu.human_attribute_name(:id)
-            th[scope='col'] = Oyatsu.human_attribute_name(:name)
-            th[scope='col'] = t('.oyatsu_count')
-        tbody
-          = render partial: 'oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu
+      - if @ensoku.basket_oyatsus.exists?
+        table.table.table-borderd.text-center.bg-white
+          thead
+            tr
+              th[scope='col'] = Oyatsu.human_attribute_name(:id)
+              th[scope='col'] = Oyatsu.human_attribute_name(:name)
+              th[scope='col'] = t('.oyatsu_count')
+          tbody
+            = render partial: 'oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu
+      - else
+        div.text-center = t('.nothing_choosed')

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -2,16 +2,16 @@
   - if user.errors.any?
     = render 'shared/error_messages', object: f.object
   div.form-group
-    = f.label :name, User.human_attribute_name(:name)
-    = f.text_field :name,  class: 'form-control', placeholder: t('.name')
+    = f.label :name, t('admin.users.common.user_name')
+    = f.text_field :name,  class: 'form-control', placeholder: t('admin.users.common.user_name')
   div.form-group
-    = f.label :email, User.human_attribute_name(:email)
-    = f.email_field :email, class: 'form-control', placeholder: t('.email')
+    = f.label :email, t('admin.users.common.email')
+    = f.email_field :email, class: 'form-control', placeholder: t('admin.users.common.email')
   div.form-group
-    = f.label :password, User.human_attribute_name(:password)
+    = f.label :password, t('.password')
     = f.password_field :password, class: 'form-control', placeholder: t('.password')
   div.form-group
-    = f.label :password_confirmation, User.human_attribute_name(:password_confirmation)
+    = f.label :password_confirmation, t('.password_confirmation')
     = f.password_field :password_confirmation, class: 'form-control', placeholder: t('.password_confirmation')
   div.form-group
     = f.label :role, User.human_attribute_name(:role)

--- a/app/views/admin/users/_search_form.html.slim
+++ b/app/views/admin/users/_search_form.html.slim
@@ -2,7 +2,7 @@
   .row
     .form-inline.align-items-center.mx-auto
       .col-auto
-        = f.search_field :name, class: 'form-control', placeholder: t('.search_word')
+        = f.search_field :name_cont, class: 'form-control', placeholder: t('.search_word')
       .col-auto
         = f.select :role_eq, User.roles_i18n.invert.map{|key, value| [key, User.roles[value]]}, { include_blank: t('.unspecified') }, { class: 'form-control mr-1' }
       .col-auto

--- a/app/views/admin/users/_search_form.html.slim
+++ b/app/views/admin/users/_search_form.html.slim
@@ -2,8 +2,8 @@
   .row
     .form-inline.align-items-center.mx-auto
       .col-auto
-        = f.search_field :name_cont, class: 'form-control', placeholder: t('.search_word')
+        = f.search_field :name_cont, class: 'form-control', placeholder: t('admin.common.search_form.search_word')
       .col-auto
-        = f.select :role_eq, User.roles_i18n.invert.map{|key, value| [key, User.roles[value]]}, { include_blank: t('.unspecified') }, { class: 'form-control mr-1' }
+        = f.select :role_eq, User.roles_i18n.invert.map{|key, value| [key, User.roles[value]]}, { include_blank: t('admin.common.search_form.unspecified') }, { class: 'form-control mr-1' }
       .col-auto
         = f.submit class: 'btn btn-primary'

--- a/app/views/admin/users/_user.html.slim
+++ b/app/views/admin/users/_user.html.slim
@@ -3,6 +3,6 @@ tr
   td = user.name
   td = user.role_i18n
   td = l user.created_at, format: :long
-  td = link_to t('.show'), admin_user_path(user), class: 'btn btn-info'
-  td = link_to t('.edit'), edit_admin_user_path(user), class: 'btn btn-success'
-  td = link_to t('.delete'), admin_user_path(user), method: :delete, data: { confirm: t('.delete_confirm') }, class: 'btn btn-danger'
+  td = link_to t('admin.common.button.show'), admin_user_path(user), class: 'btn btn-info'
+  td = link_to t('admin.common.button.edit'), edit_admin_user_path(user), class: 'btn btn-success'
+  td = link_to t('admin.common.button.delete'), admin_user_path(user), method: :delete, data: { confirm: t('.delete_confirm') }, class: 'btn btn-danger'

--- a/app/views/admin/users/_user.html.slim
+++ b/app/views/admin/users/_user.html.slim
@@ -5,4 +5,4 @@ tr
   td = l user.created_at, format: :long
   td = link_to t('.show'), admin_user_path(user), class: 'btn btn-info'
   td = link_to t('.edit'), edit_admin_user_path(user), class: 'btn btn-success'
-  td = link_to t('.delete'), admin_user_path(user), method: :delete, data: { confirm: t('.delete_confirm') }, class: 'btn btn-danger' 
+  td = link_to t('.delete'), admin_user_path(user), method: :delete, data: { confirm: t('.delete_confirm') }, class: 'btn btn-danger'

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -14,7 +14,7 @@
         thead
           tr
             th[scope="col"] = User.human_attribute_name(:id)
-            th[scope="col"] = t('.user_name')
+            th[scope="col"] = t('admin.users.common.user_name')
             th[scope="col"] = User.human_attribute_name(:role)
             th[scope="col"] = User.human_attribute_name(:created_at)
             th[scope="col"]

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -14,7 +14,7 @@
         thead
           tr
             th[scope="col"] = User.human_attribute_name(:id)
-            th[scope="col"] = User.human_attribute_name(:name)
+            th[scope="col"] = t('.user_name')
             th[scope="col"] = User.human_attribute_name(:role)
             th[scope="col"] = User.human_attribute_name(:created_at)
             th[scope="col"]

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -5,20 +5,20 @@
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1 = t('.title')
       .text-right.mb-3
-        = link_to t('admin.users.user.edit'), edit_admin_user_path(@user), class: 'btn btn-success mx-3'
-        = link_to t('admin.users.user.delete'), admin_user_path(@user), method: :delete, data: { confirm: t('admin.users.delete.delete_confirm') }, class: 'btn btn-danger'
+        = link_to t('admin.common.button.edit'), edit_admin_user_path(@user), class: 'btn btn-success mx-3'
+        = link_to t('admin.common.button.delete'), admin_user_path(@user), method: :delete, data: { confirm: t('admin.users.delete.delete_confirm') }, class: 'btn btn-danger'
       table.table.table-bordered.bg-white
         tr
           th[scope="row"] = User.human_attribute_name(:id)
           td = @user.id
         tr
-          th[scope="row"] = User.human_attribute_name(:email)
+          th[scope="row"] = t('admin.users.common.email')
           td = @user.email
         tr
           th[scope="row"] = User.human_attribute_name(:role)
           td = @user.role_i18n
         tr
-          th[scope="row"] = User.human_attribute_name(:name)
+          th[scope="row"] = t('admin.users.common.user_name')
           td = @user.name
         tr
           th[scope="row"] = User.human_attribute_name(:created_at)

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,11 +23,13 @@
 # folder are loaded and reloaded automatically when you change them, just like
 # this file (`config/breadcrumbs.rb`).
 
+# --- root ---
 # admin root crumb
 crumb :admin_root do
   link t('.admin_root'), admin_root_path
 end
 
+# --- user ---
 # users index
 crumb :admin_users do
   link t('admin.users.index.title'), admin_users_path
@@ -49,4 +51,16 @@ end
 crumb :edit_admin_user do |user|
   link admin_user.name, edit_admin_user_path(admin_user)
   parent :admin_users
+end
+
+# --- ensoku ---
+# ensoku_index
+crumb :admin_ensokus do
+  link t('admin.ensokus.index.title'), admin_ensokus_path
+end
+
+# ensoku show
+crumb :admin_ensoku do |ensoku|
+  link ensoku.id, admin_ensoku_path(ensoku)
+  parent :admin_ensokus
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,13 +12,17 @@ ja:
         id: 'ID'
         role: '権限'
         created_at: '作成日'
-        show: '確認'
-        edit: '編集'
-        delte: '削除'
       ensoku:
         comment: 'こめんと'
         purse: 'のこりのおこづかい'
         status: 'こうかいすてーたす'
+        # 管理画面用
+        id: 'ID'
+        created_at: '作成日'
+      oyatsu:
+        # 管理画面用
+        id: 'ID'
+        name: '名前'
   enums:
     user:
       role:

--- a/config/locales/views/admin/ensokus/ja.yml
+++ b/config/locales/views/admin/ensokus/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  admin:
+    ensokus:
+      common:
+        user_name: 'ユーザー名'
+        purse: '残高'
+        comment: 'コメント'
+        status: '公開ステータス'
+      index:
+        title: '遠足一覧'
+      show:
+        title: '遠足詳細'
+        info: '基本情報'
+        choosed_oyatsu: '選択したおやつ'
+        oyatsu_count: '数量'

--- a/config/locales/views/admin/ensokus/ja.yml
+++ b/config/locales/views/admin/ensokus/ja.yml
@@ -10,6 +10,18 @@ ja:
         title: '遠足一覧'
       show:
         title: '遠足詳細'
-        info: '基本情報'
-        choosed_oyatsu: '選択したおやつ'
+        info: '情報'
+        choosed_oyatsu: '選択されたおやつ'
         oyatsu_count: '数量'
+        nothing_choosed: '選択されたおやつはありません'
+      edit:
+        title: '遠足情報編集'
+      update:
+        success: '遠足情報を更新しました。'
+        failure: '遠足情報の更新に失敗しました。'
+      destroy:
+        success: '遠足の削除に成功しました。'
+      form:
+        submit: '登録'
+      ensoku:
+        delete_confirm: '本当に削除しますか？'

--- a/config/locales/views/admin/users/ja.yml
+++ b/config/locales/views/admin/users/ja.yml
@@ -4,6 +4,7 @@ ja:
       index:
         title: 'ユーザー一覧'
         new_registry: 'ユーザー新規登録'
+        user_name: 'ユーザー名'
       new:
         title: 'ユーザー新規作成'
       create:

--- a/config/locales/views/admin/users/ja.yml
+++ b/config/locales/views/admin/users/ja.yml
@@ -19,9 +19,6 @@ ja:
       destroy:
         success: 'ユーザーの削除に成功しました'
       user:
-        show: '詳細'
-        edit: '編集'
-        delete: '削除'
         delete_confirm: '本当にユーザーを削除しますか？'
       form:
         name: '名前'
@@ -29,6 +26,3 @@ ja:
         password: 'パスワード'
         password_confirmation: 'パスワード(確認)'
         submit: '登録'
-      search_form:
-        search_word: '検索する単語を入力'
-        unspecified: '未選択'

--- a/config/locales/views/admin/users/ja.yml
+++ b/config/locales/views/admin/users/ja.yml
@@ -1,10 +1,12 @@
 ja:
   admin:
     users:
+      common:
+        user_name: 'ユーザー名'
+        email: 'メールアドレス'
       index:
         title: 'ユーザー一覧'
         new_registry: 'ユーザー新規登録'
-        user_name: 'ユーザー名'
       new:
         title: 'ユーザー新規作成'
       create:
@@ -22,8 +24,6 @@ ja:
       user:
         delete_confirm: '本当にユーザーを削除しますか？'
       form:
-        name: '名前'
-        email: 'メールアドレス'
         password: 'パスワード'
         password_confirmation: 'パスワード(確認)'
         submit: '登録'

--- a/config/locales/views/common/ja.yml
+++ b/config/locales/views/common/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  admin:
+    common:
+      button:
+        show: '詳細'
+        edit: '編集'
+        delete: '削除'
+      search_form:
+        search_word: '検索する単語を入力'
+        unspecified: '未選択'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     post    'login',  to: 'user_sessions#create'
     delete  'logout', to: 'user_sessions#destroy'
     resources :users, shallow: true
-    resources :ensokus, shallow: true
+    resources :ensokus, only: %i[index show edit update destroy], shallow: true
     resources :oyatsus, shallow: true
   end
 end


### PR DESCRIPTION
# **概要**

遠足管理画面を追加しました。

# **影響範囲**

管理画面

# **確認方法**

1. 管理画面のサイドバーから遠足管理を選択し、遠足一覧が表示されることを確認してください。
2. 一覧画面から詳細情報を確認してください。
3. 詳細情報からコメントとステータスを更新出来ることを確認してください。
4. 該当の遠足を削除できることを確認してください。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**

その遠足にて選択したおやつに関しては変更をするのは違うと思い、管理機能には追加しませんでした。