### PR TITLE
Improve: スクレイピングライブラリのログをdevelopment.logに流すように改善

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,8 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Loggerの設定を追加
+  config.logger = Logger.new('log/development.log')
+
 end

--- a/lib/scraping/download_image.rb
+++ b/lib/scraping/download_image.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 module Scraping::DownloadImage
   # 読み込み確認用メソッド
   def check_download_image
-    p 'DownloadImageの読み込みOK'
+    logger.info 'DownloadImageの読み込みOK'
   end
 
   # スクレイピングにて取得した画像URLを全てダウンロードする
@@ -27,20 +27,23 @@ module Scraping::DownloadImage
   # ダウンロードメソッド
   def download_image(image_url, file_path)
     # image_urlもしくはファイルが存在する場合はダウンロードしない
-    return 'ファイルが存在します' if File.exist?(file_path)
+    if File.exist?(file_path)
+      logger.warn 'ファイルが存在します'
+      return
+    end
 
     # いらないかもだけど念の為対象URLへの負荷対策としてsleepを仕込んでおく
     sleep 1
     begin
-      p image_url
-      p file_path
+      logger.info image_url
+      logger.info  file_path
       File.open(file_path, 'w+b') do |f|
         URI.parse(image_url).open do |u|
           f.write(u.read)
         end
       end
     rescue NoMethodError => e
-      p  e.message
+      logger.error e.message
     end
   end
 

--- a/lib/scraping/scraping_core.rb
+++ b/lib/scraping/scraping_core.rb
@@ -2,24 +2,22 @@ require 'open-uri'
 require 'nokogiri'
 
 # スクレイピングライブラリ
-module Scraping
-  # スクレイピングのコア機能
-  module ScrapingCore
-    def check_scraping_core
-      p 'ScrapingCoreの読み込みOK'
-    end
+# # スクレイピングのコア機能
+module Scraping::ScrapingCore
+  def check_scraping_core
+    logger.info 'ScrapingCoreの読み込みOK'
+  end
 
-    # 対象のURLをパースする
-    def parse_document(url)
-      # システム負荷対策の1.5~3秒ランダムスリープ
-      sleep rand(1.5..3.0)
-      p url
-      begin
-        doc = Nokogiri::HTML.parse(URI.parse(url).open.read)
-      rescue OpenURI::HTTPError => e
-        p e.message
-      end
-      doc
+  # 対象のURLをパースする
+  def parse_document(url)
+    # システム負荷対策の1.5~3秒ランダムスリープ
+    sleep rand(1.5..3.0)
+    logger.info url
+    begin
+      doc = Nokogiri::HTML.parse(URI.parse(url).open.read)
+    rescue OpenURI::HTTPError => e
+      logger.error e.message
     end
+    doc
   end
 end

--- a/lib/scraping/yaokin.rb
+++ b/lib/scraping/yaokin.rb
@@ -16,7 +16,7 @@ module Scraping::Yaokin
 
   # 確認用スクリプト
   def check_scraping_yaokin
-    p '読み込めてるよ！'
+    logger.info '読み込めてるよ！'
   end
 
   # やおきんのおかしデータを取得する
@@ -101,7 +101,7 @@ module Scraping::Yaokin
       # 商品イメージののファイル名を取得
       item_data[:oyatsu_image] = item_data[:image_url].split('/').last
 
-      p item_data
+      logger.info item_data
       item.push item_data
     end
     item


### PR DESCRIPTION
# **概要**

スクレイピングライブラリのログをdevelopment.logに流すように改善しました。

# **影響範囲**

- スクレイピングライブラリ

# **確認方法**

1. やおきんの情報をスクレイピングするスクリプトを実行し、development.logにログが流れていることを確認してください。
2. スクレイピングした画像をダウンロードするスクリプトを実行し、development.logにログが流れていることを確認してください。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした
