### PR TITLE
Fix: フロントエンドにて違和感やバグだった箇所を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,17 +32,17 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
   position: relative;
   background-size: cover;
   min-height: 100vh;
+  background-image: image-url("top.jpg");
 }
 
 .main-bg:before {
   content: '';
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   background-color: rgba(0, 0, 0, 0.65);
-}
-
-.main-bg-img {
-  background-image: image-url("top.jpg");
 }
 
 .main-inner-text {
@@ -53,9 +53,10 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
   padding-bottom: 10vh;
 }
 
-.center-and-white {
+.main-text {
   text-align: center;
   color: white;
+  z-index: 1;
 }
 
 // ヘッダー要素
@@ -144,4 +145,13 @@ h3 .h3 {
   margin-bottom: 1rem;
   display: inline-block;
   color: $black;
+}
+
+thead th {
+  background-color : #ff5858!important;
+  color: white;
+}
+
+th {
+  font-weight: inherit;
 }

--- a/app/assets/stylesheets/oyatsus.scss
+++ b/app/assets/stylesheets/oyatsus.scss
@@ -2,19 +2,6 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
-.oyatsus-bg {
-  position: relative;
-  background-size: cover;
-  padding-top: 10vh;
-  min-height: 100vh;
-}
-
-.oyatsus-bg:before {
-  content: '';
-  position: absolute;
-  background-color: rgba(0, 0, 0, 0.65);
-}
-
 .card-wrapper {
   background-image: linear-gradient(120deg, #fdfbfb 0%, #ebedee 100%);
   display: flex;

--- a/app/views/ensokus/_data.html.slim
+++ b/app/views/ensokus/_data.html.slim
@@ -1,8 +1,12 @@
-div.card.card-wrapper.box-shadow.text-center
-  div.card-body.card-result-style
-    div.mt-3.mb-1 = "#{Ensoku.human_attribute_name(:comment)}:"
-    h3 = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
-    div.mt-3.mb-1= "#{Ensoku.human_attribute_name(:status)}:"
-    h3 = ensoku.status_i18n
-    div.mt-3.mb-1 = "#{Ensoku.human_attribute_name(:purse)}:"
-    h3 = "#{ensoku.purse} #{t('.yen')}"
+div.table-responsive.text-nowrap
+  table.table.table-striped
+    thead.table-striped
+      tr
+        th scope='col' = Ensoku.human_attribute_name(:comment)
+        th scope='col' = Ensoku.human_attribute_name(:status)
+        th scope='col' = Ensoku.human_attribute_name(:purse)
+    tbody.table-light
+      tr.text-center
+        th = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
+        th = ensoku.status_i18n
+        th = "#{ensoku.purse} #{t('.yen')}"

--- a/app/views/ensokus/_edit_form.html.slim
+++ b/app/views/ensokus/_edit_form.html.slim
@@ -4,11 +4,11 @@ section.form-box
       = render 'shared/error_messages', object: f.object
     - if logged_in?
       div.form-group
-        h5 = f.label :comment, Ensoku.human_attribute_name(:comment)
+        h3 = f.label :comment, Ensoku.human_attribute_name(:comment)
         = f.text_field :comment, class: 'form-control', placeholder: t('.comment')
       div.form-group
-        h5 = f.label :status, Ensoku.human_attribute_name(:status)
-        = f.select :status, Ensoku.statuses_i18n.invert, class: 'form-control', placeholder: t('.ensoku')
+        h3 = f.label :status, Ensoku.human_attribute_name(:status)
+        = f.select :status, Ensoku.statuses_i18n.invert, {}, {class: 'form-select'}
     - else
       div.form-group
         = f.hidden_field :comment, class: 'form-control', value: 'no_comment'
@@ -16,5 +16,5 @@ section.form-box
         = f.hidden_field :status, class: 'form-control', value: 'close'
     = f.submit t('.submit'), class: 'btn btn-light'
   - if logged_in?
-    div.mt-3.mb-3.center-and-white
+    div.mt-3.mb-3.text-center
       div = link_to t('.delete'), ensoku_path(@ensoku), method: :delete, class: 'btn btn-outline-danger btn-sm', data: {confirm: t('.really')}

--- a/app/views/ensokus/_ensoku.html.slim
+++ b/app/views/ensokus/_ensoku.html.slim
@@ -4,5 +4,5 @@ tr
   td.align-middle = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
   td.align-middle = ensoku.status_i18n
   td.align-middle = ensoku.purse
-  td.align-middle = link_to t('.see'), ensoku_path(ensoku), class: 'btn btn-sm btn-outline-light'
-  td.align-middle = link_to t('.again'), choose_oyatsu_path(ensoku: ensoku), class: 'btn btn-sm btn-outline-light'
+  td.align-middle = link_to t('.see'), ensoku_path(ensoku), class: 'btn btn-sm btn-outline-dark'
+  td.align-middle = link_to t('.again'), choose_oyatsu_path(ensoku: ensoku), class: 'btn btn-sm btn-outline-dark'

--- a/app/views/ensokus/edit.html.slim
+++ b/app/views/ensokus/edit.html.slim
@@ -1,19 +1,19 @@
 - content_for :title, t('.title')
 - if @ensoku.basket_oyatsus
-  div.main-wrapper.main-bg.main-bg-img
+  div.main-wrapper.main-bg
     div.container
       div.row
-        div.col.mt-3.mb-3.center-and-white
+        div.col.mt-3.mb-3.main-text
           h1 = t('.title')
           h2 = render 'okozukai'
       div.row
         = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu
       div.row
-        div.col.center-and-white
+        div.col.main-text
           = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'
           = render 'edit_form', ensoku: @ensoku
 - else
-  div.main-wrapper.main-bg.main-bg-img
+  div.main-wrapper.main-bg
     div.main-inner-text
       h1.mt-3.mb-3.font-weight-normal = t('.no_result')
       = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light mt-3'

--- a/app/views/ensokus/index.html.slim
+++ b/app/views/ensokus/index.html.slim
@@ -1,10 +1,10 @@
 - content_for :title
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text.px-5
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     - if @ensokus.present?
       div.table-responsive.text-nowrap
-        table.table
+        table.table.table-striped
           thead
             tr
               th scope='col' = t('.number')
@@ -13,7 +13,7 @@ div.main-wrapper.main-bg.main-bg-img
               th scope='col' = Ensoku.human_attribute_name(:purse)
               th scope='col' = t('.show')
               th scope='col' = t('.rechoose')
-          tbody
+          tbody.table-light
               = render @ensokus
     - else
       h3 = t('.please_choose_oyatsu')

--- a/app/views/ensokus/new.html.slim
+++ b/app/views/ensokus/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')

--- a/app/views/ensokus/show.html.slim
+++ b/app/views/ensokus/show.html.slim
@@ -1,15 +1,15 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
-  div.container
+div.main-wrapper.main-bg
+  div.container.main-text
     div.row
       div.col.mt-3.mb-3
-        h1.font-weight-normal.center-and-white = t('.title')
+        h1.= t('.title')
     div.row
       - if @ensoku.basket_oyatsus.present?
         = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu
       - else
         div.col
-          h2.font-weight-normal.center-and-white = t('.please_choose')
+          h2.font-weight-normal.text-center = t('.nothing_choosed')
     div.row
       div.col.mt-3
         div.mb-3.text-center = link_to '#', class: 'btn btn-outline-light'
@@ -18,12 +18,12 @@ div.main-wrapper.main-bg.main-bg-img
         div.mb-3.text-center = link_to t('.rechoose'), choose_oyatsu_path(ensoku: @ensoku), class: 'btn btn-outline-light'
         - if logged_in?
           div.d-flex.justify-content-center = render 'data', ensoku: @ensoku
-          div.mb-3.text-center = link_to t('.edit'), edit_ensoku_path(@ensoku), class: 'btn btn-outline-light'
+          div.my-3.text-center = link_to t('.edit'), edit_ensoku_path(@ensoku), class: 'btn btn-outline-light'
     div.row
       div.col
         - if logged_in?
           div.mb-3.text-center = link_to t('.index'), ensokus_path, class: 'btn btn-outline-light'
         - else
-          div.center-and-white.mb-3 = render 'shared/registry_merit'
+          div.mb-3.text-center = render 'shared/registry_merit'
           div.mb-3.text-center = link_to t('.new_registry'), new_users_path, class: 'btn btn-outline-light'
           div.mb-3.text-center = link_to t('.login'), login_path, class: 'btn btn-outline-light'

--- a/app/views/everyone_oyatsus/_data.html.slim
+++ b/app/views/everyone_oyatsus/_data.html.slim
@@ -1,6 +1,10 @@
-div.card.card-wrapper.box-shadow.text-center
-  div.card-body.card-result-style
-    div.mt-3.mb-1 = "#{Ensoku.human_attribute_name(:comment)}:"
-    h3 = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
-    div.mt-3.mb-1 = "#{Ensoku.human_attribute_name(:purse)}:"
-    h3 = "#{ensoku.purse} #{t('.yen')}"
+div.table-responsive.text-nowrap
+  table.table.table-striped
+    thead
+      tr
+        th scope='col' = Ensoku.human_attribute_name(:comment)
+        th scope='col' = Ensoku.human_attribute_name(:purse)
+    tbody.table-light
+      tr
+        th = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
+        th = "#{ensoku.purse} #{t('.yen')}"

--- a/app/views/everyone_oyatsus/_ensoku.html.slim
+++ b/app/views/everyone_oyatsus/_ensoku.html.slim
@@ -2,4 +2,4 @@ tr
   td.align-middle = ensoku.user.name
   td.align-middle = ensoku.comment.blank? ? t('.no_comment') : ensoku.comment
   td.align-middle = ensoku.purse
-  td.align-middle = link_to t('.see'), everyone_oyatsu_path(ensoku.id), class: 'btn btn-sm btn-outline-light'
+  td.align-middle = link_to t('.see'), everyone_oyatsu_path(ensoku.id), class: 'btn btn-sm btn-outline-dark'

--- a/app/views/everyone_oyatsus/index.html.slim
+++ b/app/views/everyone_oyatsus/index.html.slim
@@ -1,17 +1,17 @@
 - content_for :title
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text.px-5
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     - if @ensokus.present?
       div.table-responsive.text-nowrap
-        table.table
+        table.table.table-striped
           thead
             tr
               th scope='col' = User.human_attribute_name(:name)
               th scope='col' = Ensoku.human_attribute_name(:comment)
               th scope='col' = Ensoku.human_attribute_name(:purse)
               th scope='col' = t('.show')
-          tbody
+          tbody.table-light
             = render partial: 'everyone_oyatsus/ensoku', collection: @ensokus, as: :ensoku
     - else
       h2 = t('.no_open')

--- a/app/views/everyone_oyatsus/show.html.slim
+++ b/app/views/everyone_oyatsus/show.html.slim
@@ -1,10 +1,10 @@
 - content_for :title, t('.title', item: @ensoku.user.name)
-div.main-wrapper.oyatsus-bg.main-bg-img
+div.main-wrapper.main-bg
   div.container
     div.row
-      div.col.mt-3.mb-3
-        h1.font-weight-normal.center-and-white = t('.title', item: @ensoku.user.name)
+      div.col.mt-3.mb-3.main-text
+        h1.font-weight-normal = t('.title', item: @ensoku.user.name)
         div.d-flex.justify-content-center = render 'data', ensoku: @ensoku
-        div.mb-3.text-center = link_to t('.everyone_oyatsu'), everyone_oyatsus_path, class: 'btn btn-outline-light'
+        div.my-3 = link_to t('.everyone_oyatsu'), everyone_oyatsus_path, class: 'btn btn-outline-light'
     div.row
-      = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus, as: :oyatsu
+      = render partial: 'oyatsus/oyatsu', collection: @ensoku.basket_oyatsus_group, as: :oyatsu

--- a/app/views/my_pages/edit.html.slim
+++ b/app/views/my_pages/edit.html.slim
@@ -1,5 +1,5 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.form-box.border

--- a/app/views/my_pages/show.html.slim
+++ b/app/views/my_pages/show.html.slim
@@ -1,13 +1,17 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     div.container
       h1.mt-3.mb-3.font-weight-normal = t('.title')
-      div.card.card-wrapper.box-shadow.text-center.text-black
-        div.card-body.card-result-style
-          h2.mt-3.mb-1 = "#{User.human_attribute_name(:name)}:"
-          h3 = "#{current_user.name}"
-          h2.mt-3.mb-1= "#{User.human_attribute_name(:email)}:"
-          h3 = "#{current_user.email}"
+      div.table-responsive.text-nowrap
+        table.table.table-striped
+          thead
+            tr
+              th scope='col' = User.human_attribute_name(:name)
+              th scope='col' = User.human_attribute_name(:email)
+          tbody.table-light
+            tr.text-center
+              th = "#{current_user.name}"
+              th = "#{current_user.email}"
       div.mb-3 = link_to t('.update'), edit_my_page_path, class: 'btn btn-outline-light mt-3'
       div = link_to t('.see_choosed_oyatsu'), ensokus_path, class: 'btn btn-outline-light'

--- a/app/views/oyatsus/index.html.slim
+++ b/app/views/oyatsus/index.html.slim
@@ -1,5 +1,5 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.container
     div.my-4
       = render 'oyatsus/search_form', q: @q, url: choose_oyatsu_path(ensoku: @ensoku)

--- a/app/views/password_resets/edit.html.slim
+++ b/app/views/password_resets/edit.html.slim
@@ -1,5 +1,5 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.form-box.border

--- a/app/views/password_resets/new.html.slim
+++ b/app/views/password_resets/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     h1.mt-3.mb-3.font-weight-normal = t('.title')
     section.form-box.border

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -13,5 +13,5 @@ footer.footer.mt-auto.text-lg-start
         div.col
           = link_to 'おといあわせ(さくしゃのTwitter)', '#', class: 'link-light'
   section
-    div.center-and-white.p-4
+    div.p-4.main-text
       h5 = t('.site_name')

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     = image_tag "logo_transparent.png", size: '300x300'
     h1.mb-3.font-weight-normal = t('.title')

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title, t('.title')
-div.main-wrapper.main-bg.main-bg-img
+div.main-wrapper.main-bg
   div.main-inner-text
     h1.mb-3.font-weight-normal = t('.title')
     section.form-box.border


### PR DESCRIPTION
# **概要**

フロントエンドにて違和感やバグだった箇所を修正しました。

# **影響範囲**

- テーブル表示が必要だった箇所
  - みんなのおやつ
  - えらんだおやつ

- 文字表示がmain-bgの後にいっていたページ

- おやつ選択結果編集フォーム

# **確認方法**

1. みんなのおやつのテーブル表示を確認してください。
2. えらんだおやつのテーブル表示を確認してください。
3. おやつ選択結果の編集フォームにて、セレクトボックスにbootstrapクラスが当てはまっているのを確認してください。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**
他、軽微修正などが多いです。