### PR TITLE
Add: sitemap generaterの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ public/uploads
 
 # ignore coverage
 coverage
+
+# ignore dump
+dump.rdb
+
+# ignore sitemap
+public/sitemap.xml.gz

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,10 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
-# --- Add Gems ---
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+### --- Add Gems ---
 # --- All Enviroments ---
 # login
 gem 'sorcery', '~> 0.16.3'
@@ -71,8 +74,8 @@ gem 'redis-actionpack'
 # 静的ページ作成
 gem 'high_voltage', '~> 3.1', '>= 3.1.2'
 
-# systemd用
-gem "sd_notify"
+# サイトマップ作成
+gem 'sitemap_generator'
 
 # --- Development and Test ---
 group :development, :test do
@@ -125,7 +128,6 @@ group :development do
   gem "capistrano3-puma"
 end
 
-
 # --- Test ---
 group :test do
 
@@ -138,7 +140,8 @@ group :test do
   gem 'simplecov', require: false
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-
+# --- Production ---
+group :production do
+  # systemd用
+  gem "sd_notify"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sitemap_generator (6.3.0)
+      builder (~> 3.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -510,6 +512,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   sd_notify
   simplecov
+  sitemap_generator
   slim-rails
   sorcery (~> 0.16.3)
   spring

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,27 @@
+# Set the host name for URL creation
+SitemapGenerator::Sitemap.default_host = Settings.default_url_options.host
+
+SitemapGenerator::Sitemap.create do
+  # Put links creation logic here.
+  #
+  # The root path '/' and sitemap index file are added automatically for you.
+  # Links are added to the Sitemap in the order they are specified.
+  #
+  # Usage: add(path, options={})
+  #        (default options are used if you don't specify)
+  #
+  # Defaults: :priority => 0.5, :changefreq => 'weekly',
+  #           :lastmod => Time.now, :host => default_host
+  #
+  # Examples:
+  #
+  # Add '/articles'
+  #
+  #   add articles_path, :priority => 0.7, :changefreq => 'daily'
+  #
+  # Add all articles:
+  #
+  #   Article.find_each do |article|
+  #     add article_path(article), :lastmod => article.updated_at
+  #   end
+end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,9 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+User-agent: Googlebot
+Disallow: /nogooglebot/
+
+User-agent: *
+Allow: /
+
+Sitemap:https://oyatsu300.com/sitemap.xml


### PR DESCRIPTION
# **概要**

サイトマップを作成するためのgemを追加しました。
また、robots.txtやgitignoreの更新を行いました。

# **影響範囲**

- sitemap
- robots.txt
- gitignore

# **確認方法**

1. Gem を追加したので `bundle install` を実行してください
2.`bundle exec rails sitemap:refresh:no_ping` を実行しサイトマップを作成してください。

# **チェックリスト**

- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした